### PR TITLE
1 GB Canary Sidechain using Drivechain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,25 @@
-Drivechain project sidechain branch
+Drivechain 1 GB sidechain branch
 =====================================
 
-[![Build Status](https://travis-ci.org/drivechain-project/bitcoin.svg?branch=sidechainBMM)](https://travis-ci.org/drivechain-project/bitcoin)
+[![Build Status](https://travis-ci.org/sjors/bitcoin.svg?branch=sidechain-1gb)](https://travis-ci.org/sjors/bitcoin)
 
-http://drivechain.info
+Based on the Drivechain Project's [example sidechain](https://github.com/drivechain-project/bitcoin/tree/sidechainBMM), which is in turn based on [Bitcoin Core v0.14](https://github.com/bitcoin/bitcoin/tree/v0.14.2).
 
-What is Bitcoin?
-----------------
+Learn more about Drivechain at http://drivechain.info. In particular, you'll need [their mainchainBMM branch](https://github.com/drivechain-project/bitcoin/tree/mainchainBMM) to run the mainchain side.
 
-Bitcoin is an experimental digital currency that enables instant payments to
-anyone, anywhere in the world. Bitcoin uses peer-to-peer technology to operate
-with no central authority: managing transactions and issuing money are carried
-out collectively by the network. Bitcoin Core is the name of open source
-software which enables the use of this currency.
-
-For more information, as well as an immediately useable, binary version of
-the Bitcoin Core software, see https://bitcoin.org/en/download, or read the
-[original whitepaper](https://bitcoincore.org/bitcoin.pdf).
+This project is not affiliated with the "official" Drivechain project. More importantly, _do not use this code with real bitcoin_. Then again, you only live once.
 
 License
 -------
 
-Bitcoin Core is released under the terms of the MIT license. See [COPYING](COPYING) for more
+Same as Bitcoin Core, namely the MIT license. See [COPYING](COPYING) for more
 information or see https://opensource.org/licenses/MIT.
 
 Development Process
 -------------------
 
-The `master` branch is regularly built and tested, but is not guaranteed to be
-completely stable. [Tags](https://github.com/bitcoin/bitcoin/tags) are created
-regularly to indicate new official, stable release versions of Bitcoin Core.
+The best place to see work in progress is this [pull request](https://github.com/Sjors/bitcoin/pull/1).
 
-The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md).
+Pull requests should be made against the `sidechain-1gb` branch. This branch will be rebased as the upstream `sidechainBMM` branch is updated, which in turn is hopefully updated whenever Bitcoin Core releases a new version.
 
-The developer [mailing list](https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev)
-should be used to discuss complicated or controversial changes before working
-on a patch set.
-
-Developer IRC can be found on Freenode at #bitcoin-core-dev.
-
-Testing
--------
-
-Testing and code review is the bottleneck for development; we get more pull
-requests than we can review and test on short notice. Please be patient and help out by testing
-other people's pull requests, and remember this is a security-critical project where any mistake might cost people
-lots of money.
-
-### Automated Testing
-
-Developers are strongly encouraged to write [unit tests](src/test/README.md) for new code, and to
-submit new unit tests for old code. Unit tests can be compiled and run
-(assuming they weren't disabled in configure) with: `make check`. Further details on running
-and extending unit tests can be found in [/src/test/README.md](/src/test/README.md).
-
-There are also [regression and integration tests](/qa) of the RPC interface, written
-in Python, that are run automatically on the build server.
-These tests can be run (if the [test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
-
-The Travis CI system makes sure that every pull request is built for Windows, Linux, and OS X, and that unit/sanity tests are run automatically.
-
-### Manual Quality Assurance (QA) Testing
-
-Changes should be tested by somebody other than the developer who wrote the
-code. This is especially important for large or high-risk changes. It is useful
-to add a test plan to the pull request description if testing the changes is
-not straightforward.
-
-Translations
-------------
-
-Changes to translations as well as new translations can be submitted to
-[Bitcoin Core's Transifex page](https://www.transifex.com/projects/p/bitcoin/).
-
-Translations are periodically pulled from Transifex and merged into the git repository. See the
-[translation process](doc/translation_process.md) for details on how this works.
-
-**Important**: We do not accept translation changes as GitHub pull requests because the next
-pull from Transifex would automatically overwrite them again.
-
-Translators should also subscribe to the [mailing list](https://groups.google.com/forum/#!forum/bitcoin-translators).
+The `sidechain-1gb-experimental` branch will be used to try out various combinations of pull requests. It may be forced pushed over at any time.


### PR DESCRIPTION
As it says in the README, do not use this with real Bitcoin (or at all). An even more experimental version, containing some unmerged PR's, can be found at #7.

## Goals
1. Learn more about how Drivechains work.
2. Create a big sidechain, where scaling problems can be experienced long before they become a problem on the main chain.
3. Remove technical debt from consensus code, where:
  a) it can be done with a modest change
  b) future changes to Core can be tracked easily

## Required Features:
- [ ] 1 GB max block weight (#9) 
- [ ] SegWit only (is that even possible?)
- [ ] All soft forks activate at / before genesis block
  - [ ] BIP30 & BIP34 (#3)
  - [ ] BIP65 (#4)
  - [ ] BIP66 (#5)
  - [ ] BIP68 & BIP112 & BIP113 (#6)
  - [ ] BIP141 & BIP143 & BIP147
  - [ ] ...
- [ ] Minimum transaction fee for first year (extended via soft forks)  
- [ ] Document consensus rule differences (BIP like process?)

## Nice to have:
- [ ] make `--with-incompatible-bdb` the default
- [ ] ?

## Usage

Note that BMM isn't fully implemented yet upstream, so although you test various parts, you can't test full process of creating blocks on the sidechain.

The instructions [here](https://github.com/drivechain-project/testing) are useful, but not up to date yet. See comments in https://github.com/drivechain-project/drivechain.info/issues/3 for more on the new stuff. You need this fork as a remote for the sidechain, using either the `sidechain-1gb` or the `sidechain-1gb-experimental` branch. Use the upstream repository for the mainchain.

## Dependencies

- [ ] upstream BMM works (RPC or UI) 
- [ ] upstream sidechain example rebased on Core `v0.15`, e.g. to take advantage of [this](https://github.com/bitcoin/bitcoin/commit/3babbcb48786372d4b22171674c4cc5a6220c294) 

## Open questions:
* does / should the default sidechain example deal with the above BIPs?