### PR TITLE
WIP, Pending BIP: [QT] support BIP-21 no125=1 param

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -172,7 +172,11 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
             i->first.remove(0, 4);
             fShouldReturnFalse = true;
         }
-
+        if (i->first == "no125" && i->second == "1")
+        {
+            rv.no125 = true;
+            fShouldReturnFalse = false;
+        }
         if (i->first == "label")
         {
             rv.label = i->second;

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -137,7 +137,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     /* Generate new receiving address */
     address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "");
     SendCoinsRecipient info(address, label,
-        ui->reqAmount->value(), ui->reqMessage->text());
+        ui->reqAmount->value(), ui->reqMessage->text(), false);
     ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setModel(model->getOptionsModel());

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -859,6 +859,8 @@ void SendCoinsDialog::coinControlUpdateLabels()
             CoinControlDialog::payAmounts.append(rcp.amount);
             if (rcp.fSubtractFeeFromAmount)
                 CoinControlDialog::fSubtractFeeFromAmount = true;
+            if (rcp.no125)
+                ui->optInRBF->setCheckState(Qt::Unchecked);
         }
     }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -38,8 +38,8 @@ class SendCoinsRecipient
 {
 public:
     explicit SendCoinsRecipient() : amount(0), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) { }
-    explicit SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message):
-        address(addr), label(_label), amount(_amount), message(_message), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) {}
+    explicit SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message, const bool& _no125):
+        address(addr), label(_label), amount(_amount), message(_message), no125(_no125), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) {}
 
     // If from an unauthenticated payment request, this is used for storing
     // the addresses, e.g. address-A<br />address-B<br />address-C.
@@ -51,6 +51,9 @@ public:
     CAmount amount;
     // If from a payment request, this is used for storing the memo
     QString message;
+    
+    // Request that RBF should not be used
+    bool no125 = false;
 
     // If from a payment request, paymentRequest.IsInitialized() will be true
     PaymentRequestPlus paymentRequest;
@@ -69,6 +72,7 @@ public:
         std::string sAddress = address.toStdString();
         std::string sLabel = label.toStdString();
         std::string sMessage = message.toStdString();
+        std::string sNo125 = no125 ? "1" : "0";
         std::string sPaymentRequest;
         if (!ser_action.ForRead() && paymentRequest.IsInitialized())
             paymentRequest.SerializeToString(&sPaymentRequest);
@@ -79,6 +83,7 @@ public:
         READWRITE(sLabel);
         READWRITE(amount);
         READWRITE(sMessage);
+        READWRITE(sNo125);
         READWRITE(sPaymentRequest);
         READWRITE(sAuthenticatedMerchant);
 
@@ -87,6 +92,7 @@ public:
             address = QString::fromStdString(sAddress);
             label = QString::fromStdString(sLabel);
             message = QString::fromStdString(sMessage);
+            no125 = sNo125=="1";
             if (!sPaymentRequest.empty())
                 paymentRequest.parse(QByteArray::fromRawData(sPaymentRequest.data(), sPaymentRequest.size()));
             authenticatedMerchant = QString::fromStdString(sAuthenticatedMerchant);


### PR DESCRIPTION
A new optional BIP-21 parameter `no125` is introduced. When set to `1`, RBF is disabled in the send screen, regardless of default or `-walletrbf` flag. The user can still enable it.

The currently implementation crashes.

In theory it should work as follows:

"Allow increasing fee" checked:
```sh
src/qt/bitcoin-qt -testnet -walletrbf=1 bitcoin:2N9ynYyhuMtjGWnH6iEWVvL6mR6SAYb4Ayx?amount=0.1
```

"Allow increasing fee" unchecked:
```sh
src/qt/bitcoin-qt -testnet -walletrbf=1 bitcoin:2N9ynYyhuMtjGWnH6iEWVvL6mR6SAYb4Ayx?amount=0.1&no125=1
```