### PR TITLE
Stratum v2 handshake using EllSwift

### DIFF
--- a/build_msvc/libsecp256k1/libsecp256k1.vcxproj
+++ b/build_msvc/libsecp256k1/libsecp256k1.vcxproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>ENABLE_MODULE_ECDH;ENABLE_MODULE_RECOVERY;ENABLE_MODULE_EXTRAKEYS;ENABLE_MODULE_SCHNORRSIG;ENABLE_MODULE_ELLSWIFT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_MODULE_RECOVERY;ENABLE_MODULE_EXTRAKEYS;ENABLE_MODULE_SCHNORRSIG;ENABLE_MODULE_ELLSWIFT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UndefinePreprocessorDefinitions>USE_ASM_X86_64;%(UndefinePreprocessorDefinitions)</UndefinePreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\src\secp256k1;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4146;4244;4267</DisableSpecificWarnings>

--- a/configure.ac
+++ b/configure.ac
@@ -1946,7 +1946,7 @@ CPPFLAGS_TEMP="$CPPFLAGS"
 unset CPPFLAGS
 CPPFLAGS="$CPPFLAGS_TEMP"
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --enable-module-ecdh"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --disable-module-ecdh"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -12,12 +12,9 @@
 
 #include <secp256k1.h>
 #include <secp256k1_ellswift.h>
-#include <secp256k1_ecdh.h>
 #include <secp256k1_extrakeys.h>
 #include <secp256k1_recovery.h>
 #include <secp256k1_schnorrsig.h>
-
-#include <util/check.h>
 
 static secp256k1_context* secp256k1_context_sign = nullptr;
 
@@ -334,51 +331,6 @@ bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const
     bool ret = secp256k1_ec_seckey_tweak_add(secp256k1_context_sign, (unsigned char*)keyChild.begin(), vout.data());
     if (!ret) keyChild.ClearKeyData();
     return ret;
-}
-
-// TODO: use https://github.com/bitcoin-core/secp256k1/pull/1198
-bool CKey::ECDH(const XOnlyPubKey& pubkey, unsigned char* output) const {
-    CKey tmp_key = *this;
-    // Negate our private key if its public key has odd Y. This is needed because
-    // secp256k1_ecdh uses ecdh_hash_function_sha256 which includes in its checksum
-    // whether the y coordinate is even.
-    // The above PR removes the need for this, by introducing secp256k1_ecdh_xonly_hash_function
-    // that does not use the y-coordinate.
-    if (!HasEvenY()) {
-        tmp_key.Negate();
-    }
-
-    secp256k1_xonly_pubkey xonly_pubkey;
-    if (!secp256k1_xonly_pubkey_parse(secp256k1_context_sign, &xonly_pubkey, pubkey.begin())) {
-        Assume(false);
-        return false;
-    }
-
-    uint8_t buf[33] = {};
-    buf[0] = 0x02;
-
-    if (!secp256k1_xonly_pubkey_serialize(secp256k1_context_sign, &buf[1], &xonly_pubkey)) {
-        Assume(false);
-        return false;
-    }
-
-    secp256k1_pubkey secp_pubkey;
-    if (!secp256k1_ec_pubkey_parse(secp256k1_context_sign, &secp_pubkey, &buf[0], 33)) {
-        Assume(false);
-        return false;
-    }
-
-    if (!secp256k1_ecdh(secp256k1_context_sign, output, &secp_pubkey, tmp_key.keydata->data(), nullptr, nullptr)) {
-        Assume(false);
-        return false;
-    }
-
-    return true;
-}
-
-bool CKey::HasEvenY() const {
-    assert(IsValid());
-    return GetPubKey().data()[0] == 0x02;
 }
 
 EllSwiftPubKey CKey::EllSwiftCreate(Span<const std::byte> ent32) const

--- a/src/key.h
+++ b/src/key.h
@@ -203,16 +203,6 @@ public:
     ECDHSecret ComputeBIP324ECDHSecret(const EllSwiftPubKey& their_ellswift,
                                        const EllSwiftPubKey& our_ellswift,
                                        bool initiating) const;
-
-    /**
-     * Perform ecdh on this key and a given public key point.
-     */
-    bool ECDH(const XOnlyPubKey& pubkey, unsigned char* output) const;
-
-    /**
-     * Returns whether the public key as an even Y coordinate.
-     */
-    bool HasEvenY() const;
 };
 
 CKey GenerateRandomKey(bool compressed = true) noexcept;

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -313,7 +313,7 @@ public:
     /** Construct a new ellswift public key from a given serialization. */
     EllSwiftPubKey(Span<const std::byte> ellswift) noexcept;
 
-    /** Decode to normal compressed CPubKey (for debugging purposes). */
+    /** Decode to normal compressed CPubKey. */
     CPubKey Decode() const;
 
     // Read-only access for serialization.

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -364,38 +364,4 @@ BOOST_AUTO_TEST_CASE(key_ellswift)
     }
 }
 
-BOOST_AUTO_TEST_CASE(ecdh_test)
-{
-    CKey initiator_key;
-    initiator_key.MakeNewKey(true);
-    while (!initiator_key.HasEvenY()) {
-        initiator_key.MakeNewKey(true);
-    }
-    BOOST_CHECK(initiator_key.HasEvenY());
-
-    CKey responder_key;
-    responder_key.MakeNewKey(true);
-    while (!responder_key.HasEvenY()) {
-        responder_key.MakeNewKey(true);
-    }
-    BOOST_CHECK(responder_key.HasEvenY());
-
-    unsigned char ecdh_output_1[32] = {};
-    unsigned char ecdh_output_2[32] = {};
-
-    // Assert both outputs are the same.
-    BOOST_CHECK(std::memcmp(&ecdh_output_1[0], &ecdh_output_2[0], 32) == 0);
-
-    // Assert different keys can reach the same ECDH outpoint.
-    XOnlyPubKey responder_pk = XOnlyPubKey(responder_key.GetPubKey());
-    BOOST_CHECK(responder_pk.IsFullyValid());
-    initiator_key.ECDH(responder_pk, ecdh_output_1);
-
-    XOnlyPubKey initiator_pk = XOnlyPubKey(initiator_key.GetPubKey());
-    BOOST_CHECK(initiator_pk.IsFullyValid());
-    responder_key.ECDH(initiator_pk, ecdh_output_2);
-
-    BOOST_CHECK(std::memcmp(&ecdh_output_1[0], &ecdh_output_2[0], 32) == 0);
-}
-
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sv2_transport_tests.cpp
+++ b/src/test/sv2_transport_tests.cpp
@@ -183,12 +183,12 @@ public:
      */
     void ProcessHandshake1() {
         if (m_test_initiator) {
-            BOOST_REQUIRE(m_received.size() == KEY_SIZE);
+            BOOST_REQUIRE(m_received.size() == ELLSWIFT_KEY_SIZE);
             m_peer_cipher->GetHandshakeState().ReadMsgEphemeralPK(MakeWritableByteSpan(m_received));
             m_received.clear();
         } else {
             BOOST_REQUIRE(m_to_send.empty());
-            m_to_send.resize(KEY_SIZE);
+            m_to_send.resize(ELLSWIFT_KEY_SIZE);
             m_peer_cipher->GetHandshakeState().WriteMsgEphemeralPK(MakeWritableByteSpan(m_to_send));
         }
 


### PR DESCRIPTION
Implements https://github.com/stratum-mining/sv2-spec/pull/66.

Matching SRI pull request: https://github.com/stratum-mining/stratum/pull/737

This changes the handshake in two ways:

1. Public keys are encoded as EllSwift: 64 instead of 32 bytes
2. ECDH is done via `ellswift_ecdh_xonly`

Both are [defined in BIP324](https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki#elligatorswift-encoding-of-curve-x-coordinates)

It _does not_ change (x-only) public encoding in the certificate.

The main implementation is in commit "Use EllSwift for handshake pubkeys and ECDH". The two revert commits allow dropping their corresponding commits in https://github.com/bitcoin/bitcoin/pull/28983