### PR TITLE
Fix certificate generation and validation

### DIFF
--- a/src/common/sv2_noise.cpp
+++ b/src/common/sv2_noise.cpp
@@ -27,9 +27,7 @@ uint256 Sv2SignatureNoiseMessage::GetHash()
     ss  << m_version
         << m_valid_from
         << m_valid_to
-        // TODO: Stratum v2 spec requires signing the static key, but SRI currently
-        //       implements this incorrectly.
-        // << m_static_key
+        << m_static_key
         ;
 
     CSHA256 hasher;

--- a/src/node/sv2_template_provider.cpp
+++ b/src/node/sv2_template_provider.cpp
@@ -78,9 +78,6 @@ Sv2TemplateProvider::Sv2TemplateProvider(ChainstateManager& chainman, CTxMemPool
     // Start validity a little bit in the past to account for clock difference
     uint32_t valid_from = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(epoch_now).count()) - 3600;
     uint32_t valid_to =  std::numeric_limits<unsigned int>::max(); // 2106
-    // TODO: Stratum v2 spec requires signing the static key using the authority key,
-    //       but SRI currently implements this incorrectly.
-    authority_key = m_static_key;
     m_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to, XOnlyPubKey(m_static_key.GetPubKey()), authority_key);
 
     // TODO: get rid of Init() ???

--- a/src/test/sv2_noise_tests.cpp
+++ b/src/test/sv2_noise_tests.cpp
@@ -56,10 +56,6 @@ BOOST_AUTO_TEST_CASE(certificate_test)
     uint32_t valid_from = now;
     uint32_t valid_to = std::numeric_limits<unsigned int>::max();
 
-    // TODO: Stratum v2 spec requires signing the static key using the authority key,
-    //       but SRI currently implements this incorrectly.
-    alice_authority_key = alice_static_key;
-
     auto alice_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
                                XOnlyPubKey(alice_static_key.GetPubKey()), alice_authority_key);
 
@@ -117,9 +113,6 @@ BOOST_AUTO_TEST_CASE(handshake_and_transport_test)
     uint32_t valid_from = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(epoch_now).count());
     uint32_t valid_to =  std::numeric_limits<unsigned int>::max();
 
-    // TODO: Stratum v2 spec requires signing the static key using the authority key,
-    //       but SRI currently implements this incorrectly.
-    bob_authority_key = bob_static_key;
     auto bob_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
                              XOnlyPubKey(bob_static_key.GetPubKey()), bob_authority_key);
 

--- a/src/test/sv2_template_provider_tests.cpp
+++ b/src/test/sv2_template_provider_tests.cpp
@@ -55,9 +55,6 @@ BOOST_AUTO_TEST_CASE(Sv2TemplateProvider_Connection_test)
     uint32_t valid_from = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(epoch_now).count());
     uint32_t valid_to =  std::numeric_limits<unsigned int>::max();
 
-    // TODO: Stratum v2 spec requires signing the static key using the authority key,
-    //       but SRI currently implements this incorrectly.
-    authority_key = static_key;
     auto certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
                                 XOnlyPubKey(static_key.GetPubKey()), authority_key);
 

--- a/src/test/sv2_transport_tests.cpp
+++ b/src/test/sv2_transport_tests.cpp
@@ -64,9 +64,6 @@ public:
         uint32_t valid_from = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(epoch_now).count());
         uint32_t valid_to =  std::numeric_limits<unsigned int>::max();
 
-        // TODO: Stratum v2 spec requires signing the static key using the authority key,
-        //       but SRI currently implements this incorrectly.
-        responder_authority_key = responder_static_key;
         auto responder_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
                                     XOnlyPubKey(responder_static_key.GetPubKey()), responder_authority_key);
 


### PR DESCRIPTION
Requires SRI to be fixed at the same time, see https://github.com/stratum-mining/stratum/issues/717

* include m_static_key in the hash that's signed
* sign using the authority key

The relevant commit is "Fix certificate generation and validation". I'll occasionally rebase this PR so it's the _only_ commit.
