### PR TITLE
Trigger spurious MSan / TSan failure on self-hosted CI

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -492,7 +492,7 @@ make cov
 # unit and functional tests.
 ```
 
-Additional LCOV options can be specified using `LCOV_OPTS`, but may be dependant
+Additional LCOV options can be specified using `LCOV_OPTS`, but may be dependent
 on the version of LCOV. For example, when using LCOV `2.x`, branch coverage can be
 enabled by setting `LCOV_OPTS="--rc branch_coverage=1"`, when configuring.
 


### PR DESCRIPTION
Trivial change to try and trigger MSan and/or TSan failure on self-hosted CI.

The two CI machines run Ubuntu 24.04 on AMD. It uses Podman 4.9.3 with an individual user per cirrus runner (with no sudo rights).

One is on kernel 5.15.0-112, the other on 6.8.0-38.