### PR TITLE
WIP: speculative templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ on:
   # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push.
   push:
     branches:
-      - '**'
+      # Disable CI on branch pushes to forks. It will still run for pull requests.
+      # This prevents CI from running twice for typical pull request workflows.
+      - 'bitcoin/**'
+      - 'bitcoin-core/**'
     tags-ignore:
       - '**'
 

--- a/contrib/completions/bash/bitcoin-cli.bash
+++ b/contrib/completions/bash/bitcoin-cli.bash
@@ -9,7 +9,7 @@ _bitcoin_rpc() {
     local rpcargs=()
     for i in ${COMP_LINE}; do
         case "$i" in
-            -conf=*|-datadir=*|-regtest|-rpc*|-testnet)
+            -conf=*|-datadir=*|-regtest|-rpc*|-testnet|-testnet4)
                 rpcargs=( "${rpcargs[@]}" "$i" )
                 ;;
         esac

--- a/contrib/signet/README.md
+++ b/contrib/signet/README.md
@@ -44,6 +44,8 @@ Adding the --ongoing parameter will then cause the signet miner to create blocks
 
     $MINER --cli="$CLI" generate --grind-cmd="$GRIND" --address="$ADDR" --nbits=$NBITS --ongoing
 
+For custom signets with a trivial challenge a PSBT is not necessary. The miner detects this for `OP_TRUE`.
+
 Other options
 -------------
 
@@ -80,4 +82,3 @@ These steps can instead be done explicitly:
       $CLI -signet -stdin submitblock
 
 This is intended to allow you to replace part of the pipeline for further experimentation (eg, to sign the block with a hardware wallet).
-

--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -96,9 +96,10 @@ def do_decode_psbt(b64psbt):
     return from_binary(CBlock, psbt.g.map[PSBT_SIGNET_BLOCK]), ser_string(scriptSig) + scriptWitness
 
 def finish_block(block, signet_solution, grind_cmd):
-    block.vtx[0].vout[-1].scriptPubKey += CScriptOp.encode_op_pushdata(SIGNET_HEADER + signet_solution)
-    block.vtx[0].rehash()
-    block.hashMerkleRoot = block.calc_merkle_root()
+    if signet_solution is not None:
+        block.vtx[0].vout[-1].scriptPubKey += CScriptOp.encode_op_pushdata(SIGNET_HEADER + signet_solution)
+        block.vtx[0].rehash()
+        block.hashMerkleRoot = block.calc_merkle_root()
     if grind_cmd is None:
         block.solve()
     else:
@@ -110,10 +111,12 @@ def finish_block(block, signet_solution, grind_cmd):
         block.rehash()
     return block
 
-def generate_psbt(tmpl, reward_spk, *, blocktime=None):
-    signet_spk = tmpl["signet_challenge"]
+def generate_psbt(block, signet_spk):
     signet_spk_bin = bytes.fromhex(signet_spk)
+    signme, spendme = signet_txs(block, signet_spk_bin)
+    return do_createpsbt(block, signme, spendme)
 
+def new_block(tmpl, reward_spk, blocktime=None):
     cbtx = create_coinbase(height=tmpl["height"], value=tmpl["coinbasevalue"], spk=reward_spk)
     cbtx.vin[0].nSequence = 2**32-2
     cbtx.rehash()
@@ -135,9 +138,10 @@ def generate_psbt(tmpl, reward_spk, *, blocktime=None):
     block.vtx[0].wit.vtxinwit = [cbwit]
     block.vtx[0].vout.append(CTxOut(0, bytes(get_witness_script(witroot, witnonce))))
 
-    signme, spendme = signet_txs(block, signet_spk_bin)
+    block.vtx[0].rehash()
+    block.hashMerkleRoot = block.calc_merkle_root()
 
-    return do_createpsbt(block, signme, spendme)
+    return block
 
 def get_reward_address(args, height):
     if args.address is not None:
@@ -177,8 +181,10 @@ def get_reward_addr_spk(args, height):
 
 def do_genpsbt(args):
     tmpl = json.load(sys.stdin)
+    signet_spk = tmpl["signet_challenge"]
     _, reward_spk = get_reward_addr_spk(args, tmpl["height"])
-    psbt = generate_psbt(tmpl, reward_spk)
+    block = new_block(tmpl, reward_spk)
+    psbt = generate_psbt(block, signet_spk)
     print(psbt)
 
 def do_solvepsbt(args):
@@ -407,14 +413,23 @@ def do_generate(args):
         # mine block
         logging.debug("Mining block delta=%s start=%s mine=%s", seconds_to_hms(mine_time-bestheader["time"]), mine_time, is_mine)
         mined_blocks += 1
-        psbt = generate_psbt(tmpl, reward_spk, blocktime=mine_time)
-        input_stream = os.linesep.join([psbt, "true", "ALL"]).encode('utf8')
-        psbt_signed = json.loads(args.bcli("-stdin", "walletprocesspsbt", input=input_stream))
-        if not psbt_signed.get("complete",False):
-            logging.debug("Generated PSBT: %s" % (psbt,))
-            sys.stderr.write("PSBT signing failed\n")
-            return 1
-        block, signet_solution = do_decode_psbt(psbt_signed["psbt"])
+        block = new_block(tmpl, reward_spk, blocktime=mine_time)
+
+        # BIP325 allows omitting the signet commitment when scriptSig and
+        # scriptWitness are both empty. This is the case for trivial
+        # challenges such as OP_TRUE
+        signet_solution = None
+        signet_spk = tmpl["signet_challenge"]
+        if signet_spk != "51":
+            psbt = generate_psbt(block, signet_spk)
+            input_stream = os.linesep.join([psbt, "true", "ALL"]).encode('utf8')
+            psbt_signed = json.loads(args.bcli("-stdin", "walletprocesspsbt", input=input_stream))
+            if not psbt_signed.get("complete",False):
+               logging.debug("Generated PSBT: %s" % (psbt,))
+               sys.stderr.write("PSBT signing failed\n")
+               return 1
+            block, signet_solution = do_decode_psbt(psbt_signed["psbt"])
+
         block = finish_block(block, signet_solution, args.grind_cmd)
 
         # submit block

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -4,7 +4,7 @@ Unauthenticated REST Interface
 The REST API can be enabled with the `-rest` option.
 
 The interface runs on the same port as the JSON-RPC interface, by default port 8332 for mainnet, port 18332 for testnet,
-port 38332 for signet, and port 18443 for regtest.
+port 48332 for testnet4, port 38332 for signet, and port 18443 for regtest.
 
 REST Interface consistency guarantees
 -------------------------------------

--- a/doc/files.md
+++ b/doc/files.md
@@ -34,12 +34,13 @@ Windows  | `%LOCALAPPDATA%\Bitcoin\` <sup>[\[1\]](#note1)</sup>
 
 3. All content of the data directory, except for `bitcoin.conf` file, is chain-specific. This means the actual data directory paths for non-mainnet cases differ:
 
-Chain option                   | Data directory path
--------------------------------|------------------------------
-`-chain=main` (default)        | *path_to_datadir*`/`
-`-chain=test` or `-testnet`    | *path_to_datadir*`/testnet3/`
-`-chain=signet` or `-signet`   | *path_to_datadir*`/signet/`
-`-chain=regtest` or `-regtest` | *path_to_datadir*`/regtest/`
+Chain option                     | Data directory path
+---------------------------------|------------------------------
+`-chain=main` (default)          | *path_to_datadir*`/`
+`-chain=test` or `-testnet`      | *path_to_datadir*`/testnet3/`
+`-chain=testnet4` or `-testnet4` | *path_to_datadir*`/testnet4/`
+`-chain=signet` or `-signet`     | *path_to_datadir*`/signet/`
+`-chain=regtest` or `-regtest`   | *path_to_datadir*`/regtest/`
 
 ## Data directory layout
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -311,13 +311,15 @@ Both variables are used as a guideline for how much space the user needs on thei
 Note that all values should be taken from a **fully synced** node and have an overhead of 5-10% added on top of its base value.
 
 To calculate `m_assumed_blockchain_size`, take the size in GiB of these directories:
-- For `mainnet` -> the data directory, excluding the `/testnet3`, `/signet`, and `/regtest` directories and any overly large files, e.g. a huge `debug.log`
+- For `mainnet` -> the data directory, excluding the `/testnet3`, `/testnet4`, `/signet`, and `/regtest` directories and any overly large files, e.g. a huge `debug.log`
 - For `testnet` -> `/testnet3`
+- For `testnet4` -> `/testnet4`
 - For `signet` -> `/signet`
 
 To calculate `m_assumed_chain_state_size`, take the size in GiB of these directories:
 - For `mainnet` -> `/chainstate`
 - For `testnet` -> `/testnet3/chainstate`
+- For `testnet4` -> `/testnet4/chainstate`
 - For `signet` -> `/signet/chainstate`
 
 Notes:

--- a/doc/stratum-v2.md
+++ b/doc/stratum-v2.md
@@ -1,0 +1,399 @@
+# Stratum v2
+
+## Design
+
+The Stratum v2 protocol specification can be found here: https://github.com/stratum-mining/sv2-spec
+
+Bitcoin Core performs the Template Provider role, and for that it implements the
+Template Distribution Protocol. When launched with `-sv2` we listen for connections
+from Job Declarator clients.
+
+A Job Declarator client might run on the same machine, e.g. for a single ASIC
+hobby miner. In a more advanced setup it might run on another machine, on the same
+local network or remote. A third possible use case is where a miner relies on a
+node run by someone else to provide the templates. Trust may not go both ways in
+that scenario, see the section on DoS.
+
+We send them a new block template whenenver out tip is updated, or when mempool
+fees have increased sufficiently. If the pool finds a block, we attempt to
+broadcast it based on a cached template.
+
+Communication with other roles uses the Noise Protocol, which has been implemented
+to the extend necessary. Its cryptographic primitives were chosen so that they
+were already present in the  Bitcoin Core project at the time of writing the spec.
+
+### Advantage over getblocktemplate RPC
+
+Although under the hood the Template Provider uses `CreateNewBlock()` just like
+the `getblocktemplate` RPC, there's a number of advantages in running a
+server with a stateful connection, and avoiding JSON RPC in general.
+
+1. Stateful, so we can have back-and-forth, e.g. requesting transaction data,
+   processing a block solution.
+2. Less (de)serializing and data sent over the wire, compared to plain text JSON
+3. Encrypted, safer (for now: less unsafe) to expose on the public internet
+4. Push based: new template is sent immediately when a new block is found rather
+   than at the next poll interval. Combined with Cluster Mempool this can
+   hopefully be done for higher fee templates too.
+5. Low friction deployment with other Stratum v2 software / devices
+
+### Message flow(s)
+
+See the [Message Types](https://github.com/stratum-mining/sv2-spec/blob/main/08-Message-Types.md)
+and [Protocol Overview](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md)
+section of the spec for all messages and their details.
+
+When a Job Declarator client connects to us, it first sends a  `SetupConnection`
+message. We reply with `SetupConnection.Success` unless something went wrong,
+e.g. version mismatch, in which case we reply with `SetupConnection.Error`.
+
+Next the client sends us their `CoinbaseOutputDataSize`. If this is invalid we
+disconnect. Otherwise we start the cycle below that repeats with every block.
+
+We send a `NewTemplate` message with `future_template` set `true`, immedidately
+followed by `SetNewPrevHash`. We _don't_ send any transaction information
+at this point. The Job Declarator client uses this to announce upstream that
+it wants to declare a new template.
+
+In the simplest setup with SRI the Job Declarator client doubles as a proxy and
+sends these two messages to all connected mining devices. They will keep
+working on their previous job until the `SetNewPrevHash` message arrives.
+Future implementations could provide an empty or speculative template before
+a new block is found.
+
+Meanwhile the pool will request, via the Job Declarator client, the transaction
+lists belonging to the template: `RequestTransactionData`. In case of a problem
+we reply with `RequestTransactionData.Error`. Otherwise we reply with the full[0]
+transaction data in `RequestTransactionData.Success`.
+
+When we find a template with higher fees, we send a `NewTemplate` message
+with `future_template` set to `false`. This is _not_ followed by `SetNewPrevHash`.
+
+Finally, if we find an actual block, the client sends us `SubmitSolution`.
+We then lookup the template (may not be the most recent one), reconstruct
+the block and broadcast it. The pool will do the same.
+
+`[0]`: When the Job Declarator client communicates with the Job Declarator
+server there is an intermediate message which sends short transaction ids
+first, followed by a `ProvideMissingTransactions` message. The spec could be
+modified to introduce a similar message here. This is especially useful when
+the Template Provider runs on a different machine than the Job Declarator
+client. Erlay might be useful here too, in a later stage.
+
+### Noise Protocol
+
+As detailed in the [Protocol Security](https://github.com/stratum-mining/sv2-spec/blob/main/04-Protocol-Security.md)
+section of the spec, Stratum v2 roles use the Noise Protocol to communicate.
+
+We only implement the parts needed for inbound connections, although not much
+code would be needed to support outbound connections as well if this is required later.
+
+The spec was written before BIP 324 peer-to-peer encryption was introduced. It
+has much in common with Noise, but for the purposes of Stratum v2 it currently
+lacks authentication. Perhaps a future version of Stratum will use this. Since
+we only communicate with the Job Declarator role, a transition to BIP 324 would
+not require waiting for the entire mining ecosystem to adopt it.
+
+An alternative to implementing the Noise Protocol in Bitcoin Core is to use a
+unix socket instead and rely on the user to install a separate tool to convert
+to this protocol. Such a tool could be provided by developers of the Job
+Declarator client.
+
+ZMQ may be slightly more convenient than a unix socket. Since the Stratum v2
+protocol is stateful we would need to use the [request-reply](https://zguide.zeromq.org/docs/chapter3/)
+mode. Currently we only use the unidirectional `ZMQ_PUB` mode, see
+[zmq_socket](http://api.zeromq.org/4-2:zmq-socket). But then Stratum v2 messages
+can be sent and received without dealing with low level sockets / buffers / bytes.
+This could be implemented as a ZmqTransport subclass of Transport. Whether this
+involves less new code than the Noise Protocol remains to be seen.
+
+### Mempool monitoring
+
+The current design calls `CreateNewBlock()` internally every `-sv2interval` seconds.
+We then broadcast the resulting block template if fees have increased enough to make
+it worth the overhead (`-sv2feedelta`). A pool may have additional rate limiting in
+place.
+
+This is better than the Stratum v1 model of a polling call to the `getblocktemplate` RPC.
+It avoids (de)serializing JSON, uses an encrypted connection and only sends data
+over the wire if fees increased.
+
+But it's still a poll based model, as opposed to the push based approach
+whenever a new block arrives. It would be better if a new template is generated
+as soon as a potentially revenue-increasing transaction is added to the mempool.
+The Cluster Mempool project might enable that.
+
+### DoS and privacy
+
+The current Template Provider should not be run on the public internet with
+unlimited access. It is not harneded against DoS attacks, nor against mempool probing.
+
+There's currently no limit to the number of Job Declarator clients that can connect,
+which could exhaust memory. There's also no limit to the amount of raw transaction
+data that can be requested.
+
+Templates reveal what is in the mempool without any delay or randomization.
+
+This is why the use of `-sv2allowip` is required when `-sv2bind` is set to
+anything other than localhost on mainnet.
+
+Future improvements should aim to reduce or eliminate the above concerns such
+that any node can run a Template Provider as a public service.
+
+## Usage
+
+Using this in a production environment is not yet recommended, but see the testing guide below.
+
+### Parameters
+
+See also `bitcoind --help`.
+
+Start Bitcoin Core with `-sv2` to start a Template Provider server with default settings.
+The listening port can be changed with `-sv2port`.
+
+By default it only accepts connections from localhost. This can be changed
+using `-sv2bind`, which requires the use of `-sv2allowip`. See DoS and Privacy below.
+
+Use `-debug=sv2` to see Stratum v2 related log messages. Set `-loglevel=sv2:trace`
+to see which messages are exchanged with the Job Declarator client.
+
+The frequency at which new templates are generated can be controlled with
+`-sv2interval`. The new templates are only submitted to connected clients if
+they are for a new block, or if fees have increased by at least `-sv2feedelta`.
+
+You may increase `-sv2interval`` to something your node can handle, and then
+adjust `-sv2feedelta` to limit back and forth with the pool.
+
+You can use `-debug=bench` to see how long block generation typically takes on
+your machine, look for `CreateNewBlock() ... (total ...ms)`. Another factor to
+consider is upstream rate limiting, see the [Job Declaration Protocol](https://github.com/stratum-mining/sv2-spec/blob/main/06-Job-Declaration-Protocol.md).
+Mining hardware may also incur a performance dip when it receives a new job.
+
+## Testing Guide
+
+Unfortunately testing still requires quite a few moving parts, and each setup has
+its own merits and issues.
+
+To get help with the stratum side of things, this Discord may be useful: https://discord.gg/fsEW23wFYs
+
+The Stratum Reference Implementation (SRI) provides example implementations of
+the various (other) Stratum v2 roles: https://github.com/stratum-mining/stratum
+
+You can set up an entire pool on your own machine. You can also connect to an
+existing pool and only run a limited set of roles on your machine, e.g. the
+Job Declarator client and Translator (v1 to v2).
+
+SRI includes a v1 and v2 CPU miner, but at the time of writing neither seems to work.
+Another CPU miner that does work, when used with the Translator: https://github.com/pooler/cpuminer
+
+### Regtest
+
+TODO
+
+This is also needed for functional test suite coverage. It's also the only test
+network doesn't need a standalone CPU miner or ASIC.
+
+Perhaps a mock Job Declator client can be added. We also need a way mine a given
+block template, akin to `generate`.
+
+To make testing easier it should be possible to use a connection without Noise Protocol.
+
+### Testnet
+
+The difficulty on testnet3 varies wildly, but typically much too high for CPU mining.
+Even when using a relatively cheap second hand miner, e.g. an S9, it could take
+days to find a block.
+
+The above means it's difficult to test the `SubmitSolution` message.
+
+#### Bring your own ASIC, use external testnet pool
+
+The following is untested.
+
+This uses an existing testnet pool. There's no need to create an account anywhere.
+The pool does not pay out the testnet coins it generates. It also currently
+doesn't censor anything, so you can't test the (solo mining) fallback behavior.
+
+First start the node:
+
+```
+src/bitcoind -testnet -sv2 -debug=sv2
+```
+
+Build and run a Job Declator client: [stratum-mining/stratum/tree/main/roles/jd-client](https://github.com/stratum-mining/stratum/tree/main/roles/jd-client
+
+This client connects to your node to receive new block templates and then "declares"
+them to a Job Declarator server. Additionally it connects to the pool itself.
+Try this config (see documentation for more):
+
+```toml
+[[upstreams]]
+# Listen for connecting miner or translator:
+downstream_address = "127.0.0.1"
+downstream_port = 34265
+
+# Connect to upstream pool:
+authority_pubkey = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"
+pool_address = "75.119.150.111:34254"
+jd_address = "75.119.150.111:34264"
+pool_signature = "Stratum v2 SRI Pool"
+```
+
+Do not change the pool signature. It (currently) must match what the pool uses
+or you will mine invalid blocks.
+
+The `coinbase_outputs` is used for fallback to solo mining. Generate an address
+of any type and then use the `getaddressinfo` RPC to find its public key.
+
+Finally you most likely need to use the v1 to v2 translator: [stratum-mining/stratum/tree/main/roles/translator](https://github.com/stratum-mining/stratum/tree/main/roles/translator),
+even when you have a stratum v2 capable miner (see notes on ASIC's and Firmware below).
+
+You need to point the translator to your job declator client, which in turn takes
+care of connecting to the pool.
+
+```toml
+# Local SRI Testnet JDC Upstream Connection
+upstream_address = "127.0.0.1"
+upstream_port = 34265
+upstream_authority_pubkey = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"
+```
+
+The `upstream_authority_pubkey` field is required but ignored.
+
+As soon as you turn on the translator, the Bitcoin Core log should show a `SetupConnection` [message](https://github.com/stratum-mining/sv2-spec/blob/main/08-Message-Types.md).
+
+Now point your ASIC to the translator. At this point you should be seeing
+`NewTemplate`, `SetNewPrevHash` and `SetNewPrevHash` messages.
+
+If the pool is down, notify someone on the above mentioned Discord.
+
+### Custom Signet
+
+Unlike testnet3, signet(s) use the regular difficulty adjustment mechanism.
+Although the default signet has very low difficulty, you can't mine on it,
+because to do so requires signing blocks using a private key that only two people have.
+
+It's possible to create a signet that does not require signatures. There's no
+such public network, because it would risk being "attacked" by very powerful
+ASIC's. They could massively increase the difficulty and then disappear, making
+it impossible for a CPU miner to append new blocks.
+
+Instead, you can create your own custom unsigned signet. Unlike regtest this
+network does have difficulty (adjustment). This allows you to test if e.g. pool
+software correctly sets and adjusts the share difficulty for each participant.
+Although for the Template Provider role this is not relevant.
+
+#### Creating the signet
+
+See also [signet/README.md](../contrib/signet/README.md)
+
+If you use the default signet for anything else, create a fresh data directory.
+
+Add the following to `bitcoin.conf`:
+
+```ini
+[signet]
+# OP_TRUE
+signetchallenge=51
+```
+
+This challenge represents "the special case where an empty solution is valid
+(i.e. scriptSig and scriptWitness are both empty)", see [BIP 325](https://github.com/bitcoin/bips/blob/master/bip-0325.mediawiki). For mining software things will look just like testnet.
+
+The new chain needs to have at least 16 blocks, or the SRI software will panick.
+So we'll mine those using `bitcoin-util grind`:
+
+```sh
+CLI="src/bitcoin-cli"
+MINER="contrib/signet/miner"
+GRIND="src/bitcoin-util grind"
+ADDR=...
+NBITS=1d00ffff
+$MINER --cli="$CLI" generate --grind-cmd="$GRIND" --address="$ADDR" --nbits=$NBITS
+```
+
+#### Mining
+
+The cleanest setup involves two connected nodes, each with their own data
+directory: one for the pool and one for the miner. By selectively breaking the
+connection you can inspect how unknown transactions in the template are requested
+by the pool, and how a newly found block is submitted is submitted both by the
+pool and the miner.
+
+However things should work fine with just one node.
+
+Start the miner node first, with a GUI for convenience:
+
+```sh
+src/qt/bitcoin-qt -datadir=$HOME/.stratum/bitcoin -signet
+```
+
+Suggested config for the pool node:
+
+```ini
+[signet]
+# OP_TRUE
+signetchallenge=51
+server=0
+listen=0
+connect=127.0.0.1
+```
+
+The above disables its RPC server and p2p listening to avoid a port conflict.
+
+Start the pool node:
+
+```sh
+src/bitcoind -datadir=$HOME/.stratum/bitcoin-pool -signet
+```
+
+Configure an SRI pool:
+
+```
+cd roles/pool
+mkdir -p ~/.stratum
+cp
+```
+
+Start the SRI pool:
+
+```sh
+cargo run -p pool_sv2 -- -c ~/.stratum/signet-pool.toml
+```
+
+For the Job Declarator _client_ and Translator, see Testnet above.
+
+Now use the [CPU miner](https://github.com/pooler/cpuminer) and point it to the translator:
+
+```
+./minerd -a sha256d -o stratum+tcp://localhost:34255 -q -D -P
+```
+
+
+#### Mining after being away
+
+The Template Provider will not start until the node is caught up.
+Use `bitcoin-util grind` as explained above for it to catch up.
+
+### Mainnet
+
+See testnet for how to use an external pool. See signet for how to configure your own pool.
+
+Pools that support Stratum v2 on mainnet:
+
+* Braiins: unclear if they are currently compatible with latest spec. URL's are
+           listed [here](https://academy.braiins.com/en/braiins-pool/stratum-v2-manual/#servers-and-ports). There's no Job Declarator server.
+* DEMAND : No account needed for solo mining. Both the pool and Job Declarator
+           server are at `dmnd.work:2000`. Requires a custom SRI branch, see [instructions](https://dmnd.work/#solo-mine).
+
+### Notes on ASIC's and Firmware:
+
+#### BraiinsOS
+
+* v22.08.1 uses an (incompatible) older version of Stratum v2
+* v23.12 is untested (and not available on S9)
+* v22.08.1 when used in Stratum v1 mode, does not work with the SRI Translator
+
+#### Antminer stock OS
+
+This should work with the Translator, but has not been tested.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,7 @@ BITCOIN_CORE_H = \
   common/bloom.h \
   common/init.h \
   common/run_command.h \
+  common/sv2_connman.h \
   common/sv2_messages.h \
   common/sv2_noise.h \
   common/sv2_transport.h \
@@ -689,6 +690,7 @@ libbitcoin_common_a_SOURCES = \
   common/interfaces.cpp \
   common/messages.cpp \
   common/run_command.cpp \
+  common/sv2_connman.cpp \
   common/sv2_noise.cpp \
   common/settings.cpp \
   common/signmessage.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,6 +139,7 @@ BITCOIN_CORE_H = \
   common/run_command.h \
   common/sv2_messages.h \
   common/sv2_noise.h \
+  common/sv2_transport.h \
   common/types.h \
   common/url.h \
   compat/assumptions.h \
@@ -691,6 +692,7 @@ libbitcoin_common_a_SOURCES = \
   common/sv2_noise.cpp \
   common/settings.cpp \
   common/signmessage.cpp \
+  common/sv2_transport.cpp \
   common/system.cpp \
   common/url.cpp \
   compressor.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,7 @@ BITCOIN_CORE_H = \
   common/bloom.h \
   common/init.h \
   common/run_command.h \
+  common/sv2_noise.h \
   common/types.h \
   common/url.h \
   compat/assumptions.h \
@@ -686,6 +687,7 @@ libbitcoin_common_a_SOURCES = \
   common/interfaces.cpp \
   common/messages.cpp \
   common/run_command.cpp \
+  common/sv2_noise.cpp \
   common/settings.cpp \
   common/signmessage.cpp \
   common/system.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,7 @@ BITCOIN_CORE_H = \
   common/bloom.h \
   common/init.h \
   common/run_command.h \
+  common/sv2_messages.h \
   common/sv2_noise.h \
   common/types.h \
   common/url.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -238,6 +238,7 @@ BITCOIN_CORE_H = \
   node/peerman_args.h \
   node/protocol_version.h \
   node/psbt.h \
+  node/sv2_template_provider.h \
   node/timeoffsets.h \
   node/transaction.h \
   node/txreconciliation.h \
@@ -443,6 +444,7 @@ libbitcoin_node_a_SOURCES = \
   node/minisketchwrapper.cpp \
   node/peerman_args.cpp \
   node/psbt.cpp \
+  node/sv2_template_provider.cpp \
   node/timeoffsets.cpp \
   node/transaction.cpp \
   node/txreconciliation.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -693,6 +693,7 @@ libbitcoin_common_a_SOURCES = \
   common/messages.cpp \
   common/run_command.cpp \
   common/sv2_connman.cpp \
+  common/sv2_messages.cpp \
   common/sv2_noise.cpp \
   common/settings.cpp \
   common/signmessage.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -152,6 +152,7 @@ BITCOIN_TESTS =\
   test/sock_tests.cpp \
   test/span_tests.cpp \
   test/streams_tests.cpp \
+  test/sv2_connman_tests.cpp \
   test/sv2_messages_tests.cpp \
   test/sv2_noise_tests.cpp \
   test/sv2_transport_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -153,6 +153,7 @@ BITCOIN_TESTS =\
   test/span_tests.cpp \
   test/streams_tests.cpp \
   test/sv2_noise_tests.cpp \
+  test/sv2_transport_tests.cpp \
   test/sync_tests.cpp \
   test/system_tests.cpp \
   test/timeoffsets_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -152,6 +152,7 @@ BITCOIN_TESTS =\
   test/sock_tests.cpp \
   test/span_tests.cpp \
   test/streams_tests.cpp \
+  test/sv2_messages_tests.cpp \
   test/sv2_noise_tests.cpp \
   test/sv2_transport_tests.cpp \
   test/sync_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -152,6 +152,7 @@ BITCOIN_TESTS =\
   test/sock_tests.cpp \
   test/span_tests.cpp \
   test/streams_tests.cpp \
+  test/sv2_noise_tests.cpp \
   test/sync_tests.cpp \
   test/system_tests.cpp \
   test/timeoffsets_tests.cpp \
@@ -388,6 +389,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/span.cpp \
  test/fuzz/string.cpp \
  test/fuzz/strprintf.cpp \
+ test/fuzz/sv2_noise.cpp \
  test/fuzz/system.cpp \
  test/fuzz/timeoffsets.cpp \
  test/fuzz/torcontrol.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -155,6 +155,7 @@ BITCOIN_TESTS =\
   test/sv2_connman_tests.cpp \
   test/sv2_messages_tests.cpp \
   test/sv2_noise_tests.cpp \
+  test/sv2_template_provider_tests.cpp \
   test/sv2_transport_tests.cpp \
   test/sync_tests.cpp \
   test/system_tests.cpp \

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -75,6 +75,7 @@ static void SetupCliArgs(ArgsManager& argsman)
 
     const auto defaultBaseParams = CreateBaseChainParams(ChainType::MAIN);
     const auto testnetBaseParams = CreateBaseChainParams(ChainType::TESTNET);
+    const auto testnet4BaseParams = CreateBaseChainParams(ChainType::TESTNET4);
     const auto signetBaseParams = CreateBaseChainParams(ChainType::SIGNET);
     const auto regtestBaseParams = CreateBaseChainParams(ChainType::REGTEST);
 
@@ -98,7 +99,7 @@ static void SetupCliArgs(ArgsManager& argsman)
     argsman.AddArg("-rpcconnect=<ip>", strprintf("Send commands to node running on <ip> (default: %s)", DEFAULT_RPCCONNECT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-rpccookiefile=<loc>", "Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-rpcpassword=<pw>", "Password for JSON-RPC connections", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-rpcport=<port>", strprintf("Connect to JSON-RPC on <port> (default: %u, testnet: %u, signet: %u, regtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), signetBaseParams->RPCPort(), regtestBaseParams->RPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-rpcport=<port>", strprintf("Connect to JSON-RPC on <port> (default: %u, testnet: %u, testnet4: %u, signet: %u, regtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), testnet4BaseParams->RPCPort(), signetBaseParams->RPCPort(), regtestBaseParams->RPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-rpcwait", "Wait for RPC server to start", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-rpcwaittimeout=<n>", strprintf("Timeout in seconds to wait for the RPC server to start, or 0 for no timeout. (default: %d)", DEFAULT_WAIT_CLIENT_TIMEOUT), ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::OPTIONS);
@@ -428,6 +429,8 @@ private:
     std::string ChainToString() const
     {
         switch (gArgs.GetChainType()) {
+        case ChainType::TESTNET4:
+            return " testnet4";
         case ChainType::TESTNET:
             return " testnet";
         case ChainType::SIGNET:

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -69,7 +69,7 @@ static std::optional<int> WalletAppInit(ArgsManager& args, int argc, char* argv[
             strUsage += "\n"
                         "bitcoin-wallet is an offline tool for creating and interacting with " PACKAGE_NAME " wallet files.\n"
                         "By default bitcoin-wallet will act on wallets in the default mainnet wallet directory in the datadir.\n"
-                        "To change the target wallet, use the -datadir, -wallet and -regtest/-signet/-testnet arguments.\n\n"
+                        "To change the target wallet, use the -datadir, -wallet and -regtest/-signet/-testnet/-testnet4 arguments.\n\n"
                         "Usage:\n"
                         "  bitcoin-wallet [options] <command>\n";
             strUsage += "\n" + args.GetHelpMessage();

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -115,6 +115,8 @@ std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, c
         return CChainParams::Main();
     case ChainType::TESTNET:
         return CChainParams::TestNet();
+    case ChainType::TESTNET4:
+        return CChainParams::TestNet4();
     case ChainType::SIGNET: {
         auto opts = CChainParams::SigNetOptions{};
         ReadSigNetArgs(args, opts);

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -17,7 +17,8 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
     argsman.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                  "This is intended for regression testing tools and app development. Equivalent to -chain=regtest.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (segwit, bip34, dersig, cltv, csv). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
-    argsman.AddArg("-testnet", "Use the test chain. Equivalent to -chain=test.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-testnet", "Use the testnet3 chain. Equivalent to -chain=test. Support for testnet3 is deprecated and will be removed with the next release. Consider moving to testnet4 now by using -testnet4.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-testnet4", "Use the testnet4 chain. Equivalent to -chain=testnet4.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-vbparams=deployment:start:end[:min_activation_height]", "Use given start/end times and min_activation_height for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signet", "Use the signet chain. Equivalent to -chain=signet. Note that the network is defined by the -signetchallenge parameter", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to the global default signet test network challenge)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
@@ -33,7 +34,7 @@ const CBaseChainParams& BaseParams()
 }
 
 /**
- * Port numbers for incoming Tor connections (8334, 18334, 38334, 18445) have
+ * Port numbers for incoming Tor connections (8334, 18334, 38334, 48334, 18445) have
  * been chosen arbitrarily to keep ranges of used ports tight.
  */
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const ChainType chain)
@@ -43,6 +44,8 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const ChainType chain)
         return std::make_unique<CBaseChainParams>("", 8332, 8334, 8336);
     case ChainType::TESTNET:
         return std::make_unique<CBaseChainParams>("testnet3", 18332, 18334, 18336);
+    case ChainType::TESTNET4:
+        return std::make_unique<CBaseChainParams>("testnet4", 48332, 48334, 48336);
     case ChainType::SIGNET:
         return std::make_unique<CBaseChainParams>("signet", 38332, 38334, 38336);
     case ChainType::REGTEST:

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -40,13 +40,13 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const ChainType chain)
 {
     switch (chain) {
     case ChainType::MAIN:
-        return std::make_unique<CBaseChainParams>("", 8332, 8334);
+        return std::make_unique<CBaseChainParams>("", 8332, 8334, 8336);
     case ChainType::TESTNET:
-        return std::make_unique<CBaseChainParams>("testnet3", 18332, 18334);
+        return std::make_unique<CBaseChainParams>("testnet3", 18332, 18334, 18336);
     case ChainType::SIGNET:
-        return std::make_unique<CBaseChainParams>("signet", 38332, 38334);
+        return std::make_unique<CBaseChainParams>("signet", 38332, 38334, 38336);
     case ChainType::REGTEST:
-        return std::make_unique<CBaseChainParams>("regtest", 18443, 18445);
+        return std::make_unique<CBaseChainParams>("regtest", 18443, 18445, 18447);
     }
     assert(false);
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -22,14 +22,16 @@ public:
     const std::string& DataDir() const { return strDataDir; }
     uint16_t RPCPort() const { return m_rpc_port; }
     uint16_t OnionServiceTargetPort() const { return m_onion_service_target_port; }
+    uint16_t Sv2Port() const { return m_sv2_port; }
 
     CBaseChainParams() = delete;
-    CBaseChainParams(const std::string& data_dir, uint16_t rpc_port, uint16_t onion_service_target_port)
-        : m_rpc_port(rpc_port), m_onion_service_target_port(onion_service_target_port), strDataDir(data_dir) {}
+    CBaseChainParams(const std::string& data_dir, uint16_t rpc_port, uint16_t onion_service_target_port, uint16_t sv2_port)
+        : m_rpc_port(rpc_port), m_onion_service_target_port(onion_service_target_port), m_sv2_port{sv2_port}, strDataDir(data_dir) {}
 
 private:
     const uint16_t m_rpc_port;
     const uint16_t m_onion_service_target_port;
+    const uint16_t m_sv2_port;
     std::string strDataDir;
 };
 

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -159,6 +159,7 @@ std::list<SectionInfo> ArgsManager::GetUnrecognizedSections() const
         ChainTypeToString(ChainType::REGTEST),
         ChainTypeToString(ChainType::SIGNET),
         ChainTypeToString(ChainType::TESTNET),
+        ChainTypeToString(ChainType::TESTNET4),
         ChainTypeToString(ChainType::MAIN),
     };
 
@@ -773,10 +774,11 @@ std::variant<ChainType, std::string> ArgsManager::GetChainArg() const
     const bool fRegTest = get_net("-regtest");
     const bool fSigNet  = get_net("-signet");
     const bool fTestNet = get_net("-testnet");
+    const bool fTestNet4 = get_net("-testnet4");
     const auto chain_arg = GetArg("-chain");
 
-    if ((int)chain_arg.has_value() + (int)fRegTest + (int)fSigNet + (int)fTestNet > 1) {
-        throw std::runtime_error("Invalid combination of -regtest, -signet, -testnet and -chain. Can use at most one.");
+    if ((int)chain_arg.has_value() + (int)fRegTest + (int)fSigNet + (int)fTestNet + (int)fTestNet4 > 1) {
+        throw std::runtime_error("Invalid combination of -regtest, -signet, -testnet, -testnet4 and -chain. Can use at most one.");
     }
     if (chain_arg) {
         if (auto parsed = ChainTypeFromString(*chain_arg)) return *parsed;
@@ -786,6 +788,7 @@ std::variant<ChainType, std::string> ArgsManager::GetChainArg() const
     if (fRegTest) return ChainType::REGTEST;
     if (fSigNet) return ChainType::SIGNET;
     if (fTestNet) return ChainType::TESTNET;
+    if (fTestNet4) return ChainType::TESTNET4;
     return ChainType::MAIN;
 }
 

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -423,7 +423,7 @@ private:
     fs::path GetDataDir(bool net_specific) const;
 
     /**
-     * Return -regtest/-signet/-testnet/-chain= setting as a ChainType enum if a
+     * Return -regtest/-signet/-testnet/-testnet4/-chain= setting as a ChainType enum if a
      * recognized chain type was set, or as a string if an unrecognized chain
      * name was set. Raise an exception if an invalid combination of flags was
      * provided.

--- a/src/common/sv2_connman.cpp
+++ b/src/common/sv2_connman.cpp
@@ -1,0 +1,387 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/sv2_connman.h>
+#include <common/sv2_messages.h>
+#include <logging.h>
+#include <sync.h>
+#include <util/thread.h>
+
+using node::Sv2MsgType;
+
+Sv2Connman::~Sv2Connman()
+{
+    AssertLockNotHeld(m_clients_mutex);
+
+    {
+        LOCK(m_clients_mutex);
+        for (const auto& client : m_sv2_clients) {
+            LogTrace(BCLog::SV2, "Disconnecting client id=%zu\n",
+                    client->m_id);
+            client->m_disconnect_flag = true;
+        }
+        DisconnectFlagged();
+    }
+
+    Interrupt();
+    StopThreads();
+}
+
+bool Sv2Connman::Start(Sv2EventsInterface* msgproc, std::string host, uint16_t port)
+{
+    m_msgproc = msgproc;
+
+    try {
+        auto sock = BindListenPort(host, port);
+        m_listening_socket = std::move(sock);
+    } catch (const std::runtime_error& e) {
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Error, "Template Provider failed to bind to port %d: %s\n", port, e.what());
+        return false;
+    }
+
+    m_thread_sv2_handler = std::thread(&util::TraceThread, "sv2connman", [this] { ThreadSv2Handler(); });
+    return true;
+}
+
+std::shared_ptr<Sock> Sv2Connman::BindListenPort(std::string host, uint16_t port) const
+{
+    const CService addr_bind = LookupNumeric(host, port);
+
+    auto sock = CreateSock(addr_bind.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
+    if (!sock) {
+        throw std::runtime_error("Sv2 Template Provider cannot create socket");
+    }
+
+    struct sockaddr_storage sockaddr;
+    socklen_t len = sizeof(sockaddr);
+
+    if (!addr_bind.GetSockAddr(reinterpret_cast<struct sockaddr*>(&sockaddr), &len)) {
+        throw std::runtime_error("Sv2 Template Provider failed to get socket address");
+    }
+
+    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
+        const int nErr = WSAGetLastError();
+        if (nErr == WSAEADDRINUSE) {
+            throw std::runtime_error(strprintf("Unable to bind to %d on this computer. Another Stratum v2 process is probably already running.\n", port));
+        }
+
+        throw std::runtime_error(strprintf("Unable to bind to %d on this computer (bind returned error %s )\n", port, NetworkErrorString(nErr)));
+    }
+
+    constexpr int max_pending_conns{4096};
+    if (sock->Listen(max_pending_conns) == SOCKET_ERROR) {
+        throw std::runtime_error("Sv2 listening socket has an error listening");
+    }
+
+    LogPrintLevel(BCLog::SV2, BCLog::Level::Info, "%s listening on %s:%d\n", SV2_PROTOCOL_NAMES.at(m_subprotocol), host, port);
+
+    return sock;
+}
+
+
+void Sv2Connman::DisconnectFlagged()
+{
+    AssertLockHeld(m_clients_mutex);
+
+    // Remove clients that are flagged for disconnection.
+    m_sv2_clients.erase(
+        std::remove_if(m_sv2_clients.begin(), m_sv2_clients.end(), [](const auto &client) {
+            return client->m_disconnect_flag;
+    }), m_sv2_clients.end());
+}
+
+void Sv2Connman::ThreadSv2Handler() EXCLUSIVE_LOCKS_REQUIRED(!m_clients_mutex)
+{
+    AssertLockNotHeld(m_clients_mutex);
+
+    while (!m_flag_interrupt_sv2) {
+        {
+            LOCK(m_clients_mutex);
+            DisconnectFlagged();
+        }
+
+        // Poll/Select the sockets that need handling.
+        Sock::EventsPerSock events_per_sock = WITH_LOCK(m_clients_mutex, return GenerateWaitSockets(m_listening_socket, m_sv2_clients));
+
+        constexpr auto timeout = std::chrono::milliseconds(50);
+        if (!events_per_sock.begin()->first->WaitMany(timeout, events_per_sock)) {
+            continue;
+        }
+
+        // Accept any new connections for sv2 clients.
+        const auto listening_sock = events_per_sock.find(m_listening_socket);
+        if (listening_sock != events_per_sock.end() && listening_sock->second.occurred & Sock::RECV) {
+            struct sockaddr_storage sockaddr;
+            socklen_t sockaddr_len = sizeof(sockaddr);
+
+            auto sock = m_listening_socket->Accept(reinterpret_cast<struct sockaddr*>(&sockaddr), &sockaddr_len);
+            if (sock) {
+                Assume(m_certificate);
+                LOCK(m_clients_mutex);
+                std::unique_ptr transport = std::make_unique<Sv2Transport>(m_static_key, m_certificate.value());
+                size_t id{m_sv2_clients.size() + 1};
+                auto client = std::make_unique<Sv2Client>(id, std::move(sock), std::move(transport));
+                LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "New client id=%zu connected\n", client->m_id);
+                m_sv2_clients.emplace_back(std::move(client));
+            }
+        }
+
+        LOCK(m_clients_mutex);
+        // Process messages from and for connected sv2_clients.
+        for (auto& client : m_sv2_clients) {
+            bool has_received_data = false;
+            bool has_error_occurred = false;
+
+            const auto socket_it = events_per_sock.find(client->m_sock);
+            if (socket_it != events_per_sock.end()) {
+                has_received_data = socket_it->second.occurred & Sock::RECV;
+                has_error_occurred = socket_it->second.occurred & Sock::ERR;
+            }
+
+            if (has_error_occurred) {
+                LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Socket receive error, disconnecting client id=%zu\n",
+                client->m_id);
+                client->m_disconnect_flag = true;
+                continue;
+            }
+
+            // Process message queue and any outbound bytes still held by the transport
+            auto it = client->m_send_messages.begin();
+            std::optional<bool> expected_more;
+            while(true) {
+                if (it != client->m_send_messages.end()) {
+                    // If possible, move one message from the send queue to the transport.
+                    // This fails when there is an existing message still being sent,
+                    // or when the handshake has not yet completed.
+                    //
+                    // Wrap Sv2NetMsg inside CSerializedNetMsg for transport
+                    CSerializedNetMsg net_msg{*it};
+                    if (client->m_transport->SetMessageToSend(net_msg)) {
+                        ++it;
+                    }
+                }
+
+                const auto& [data, more, _m_message_type] = client->m_transport->GetBytesToSend(/*have_next_message=*/it != client->m_send_messages.end());
+                size_t total_sent = 0;
+
+                // We rely on the 'more' value returned by GetBytesToSend to correctly predict whether more
+                // bytes are still to be sent, to correctly set the MSG_MORE flag. As a sanity check,
+                // verify that the previously returned 'more' was correct.
+                if (expected_more.has_value()) Assume(!data.empty() == *expected_more);
+                expected_more = more;
+                ssize_t sent = 0;
+
+                if (!data.empty()) {
+                    int flags = MSG_NOSIGNAL | MSG_DONTWAIT;
+#ifdef MSG_MORE
+            if (more) {
+                flags |= MSG_MORE;
+            }
+#endif
+                    LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Send %d bytes to client id=%zu\n",
+                                  data.size() - total_sent, client->m_id);
+                    sent = client->m_sock->Send(data.data() + total_sent, data.size() - total_sent, flags);
+                }
+                if (sent > 0) {
+                    // Notify transport that bytes have been processed.
+                    client->m_transport->MarkBytesSent(sent);
+                    if ((size_t)sent != data.size()) {
+                        // could not send full message; stop sending more
+                        break;
+                    }
+                } else {
+                    if (sent < 0) {
+                        // error
+                        int nErr = WSAGetLastError();
+                        if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS) {
+                            LogPrintLevel(BCLog::SV2, BCLog::Level::Debug, "Socket send error for  client id=%zu: %s\n",
+                                          client->m_id, NetworkErrorString(nErr));
+                            client->m_disconnect_flag = true;
+                        }
+                    }
+                    break;
+                }
+            }
+            // Clear messages that have been handed to transport from the queue
+            client->m_send_messages.erase(client->m_send_messages.begin(), it);
+
+            // Stop processing this client if something went wrong during sending
+            if (client->m_disconnect_flag) break;
+
+            if (has_received_data) {
+                uint8_t bytes_received_buf[0x10000];
+
+                const auto num_bytes_received = client->m_sock->Recv(bytes_received_buf, sizeof(bytes_received_buf), MSG_DONTWAIT);
+                LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Num bytes received from client id=%zu: %d\n",
+                              client->m_id, num_bytes_received);
+
+                if (num_bytes_received <= 0) {
+                    LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Disconnecting client id=%zu\n",
+                                  client->m_id);
+                    client->m_disconnect_flag = true;
+                    break;
+                }
+
+                try
+                {
+                    auto msg_ = Span(bytes_received_buf, num_bytes_received);
+                    Span<const uint8_t> msg(reinterpret_cast<const uint8_t*>(msg_.data()), msg_.size());
+                    while (msg.size() > 0) {
+                        // absorb network data
+                        if (!client->m_transport->ReceivedBytes(msg)) {
+                            // Serious transport problem
+                            LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Transport problem, disconnecting client id=%zu\n",
+                                          client->m_id);
+                            client->m_disconnect_flag = true;
+                            break;
+                        }
+
+                        if (client->m_transport->ReceivedMessageComplete()) {
+                            bool dummy_reject_message = false;
+                            Sv2NetMsg msg = client->m_transport->GetReceivedMessage(std::chrono::milliseconds(0), dummy_reject_message);
+                            ProcessSv2Message(msg, *client.get());
+                        }
+                    }
+                } catch (const std::exception& e) {
+                    LogPrintLevel(BCLog::SV2, BCLog::Level::Error, "Received error when processing client id=%zu message: %s\n", client->m_id, e.what());
+                    client->m_disconnect_flag = true;
+                }
+            }
+        }
+    }
+}
+
+Sock::EventsPerSock Sv2Connman::GenerateWaitSockets(const std::shared_ptr<Sock>& listen_socket, const Clients& sv2_clients) const
+{
+    Sock::EventsPerSock events_per_sock;
+    events_per_sock.emplace(listen_socket, Sock::Events(Sock::RECV));
+
+    for (const auto& client : sv2_clients) {
+        if (!client->m_disconnect_flag && client->m_sock) {
+            events_per_sock.emplace(client->m_sock, Sock::Events{Sock::RECV | Sock::ERR});
+        }
+    }
+
+    return events_per_sock;
+}
+
+void Sv2Connman::Interrupt()
+{
+    m_flag_interrupt_sv2 = true;
+}
+
+void Sv2Connman::StopThreads()
+{
+    if (m_thread_sv2_handler.joinable()) {
+        m_thread_sv2_handler.join();
+    }
+}
+
+void Sv2Connman::ProcessSv2Message(const Sv2NetMsg& sv2_net_msg, Sv2Client& client)
+{
+    uint8_t msg_type[1] = {uint8_t(sv2_net_msg.m_msg_type)};
+    LogPrintLevel(BCLog::SV2, BCLog::Level::Debug, "Received 0x%s %s from client id=%zu\n",
+                   // After clang-17:
+                   // std::format("{:x}", uint8_t(sv2_net_msg.m_msg_type)),
+                   HexStr(msg_type),
+                   node::SV2_MSG_NAMES.at(sv2_net_msg.m_msg_type), client.m_id);
+
+    DataStream ss (sv2_net_msg.m_msg);
+
+    switch (sv2_net_msg.m_msg_type)
+    {
+    case Sv2MsgType::SETUP_CONNECTION:
+    {
+        if (client.m_setup_connection_confirmed) {
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Error, "Client client id=%zu connection has already been confirmed\n",
+                          client.m_id);
+            return;
+        }
+
+        node::Sv2SetupConnectionMsg setup_conn;
+        try {
+            ss >> setup_conn;
+        } catch (const std::exception& e) {
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Error, "Received invalid SetupConnection message from client id=%zu: %s\n",
+                          client.m_id, e.what());
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        // Disconnect a client that connects on the wrong subprotocol.
+        if (setup_conn.m_protocol != m_subprotocol) {
+            node::Sv2SetupConnectionErrorMsg setup_conn_err{setup_conn.m_flags, std::string{"unsupported-protocol"}};
+
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Debug, "Send 0x02 SetupConnectionError to client id=%zu\n",
+                          client.m_id);
+            client.m_send_messages.emplace_back(setup_conn_err);
+
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        // Disconnect a client if they are not running a compatible protocol version.
+        if ((m_protocol_version < setup_conn.m_min_version) || (m_protocol_version > setup_conn.m_max_version)) {
+            node::Sv2SetupConnectionErrorMsg setup_conn_err{setup_conn.m_flags, std::string{"protocol-version-mismatch"}};
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Debug, "Send 0x02 SetupConnection.Error to client id=%zu\n",
+                          client.m_id);
+            client.m_send_messages.emplace_back(setup_conn_err);
+
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Error, "Received a connection from client id=%zu with incompatible protocol_versions: min_version: %d, max_version: %d\n",
+                          client.m_id, setup_conn.m_min_version, setup_conn.m_max_version);
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Debug, "Send 0x01 SetupConnection.Success to client id=%zu\n",
+                      client.m_id);
+        node::Sv2SetupConnectionSuccessMsg setup_success{m_protocol_version, m_optional_features};
+        client.m_send_messages.emplace_back(setup_success);
+
+        client.m_setup_connection_confirmed = true;
+
+        break;
+    }
+    case Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE:
+    {
+        if (!client.m_setup_connection_confirmed) {
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        node::Sv2CoinbaseOutputDataSizeMsg coinbase_output_data_size;
+        try {
+            ss >> coinbase_output_data_size;
+            client.m_coinbase_output_data_size_recv = true;
+        } catch (const std::exception& e) {
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Error, "Received invalid CoinbaseOutputDataSize message from client id=%zu: %s\n",
+                          client.m_id, e.what());
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        uint32_t max_additional_size = coinbase_output_data_size.m_coinbase_output_max_additional_size;
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Debug, "coinbase_output_max_additional_size=%d bytes\n", max_additional_size);
+
+        if (max_additional_size > MAX_BLOCK_WEIGHT) {
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Error, "Received impossible CoinbaseOutputDataSize from client id=%zu: %d\n",
+                          client.m_id, max_additional_size);
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        client.m_coinbase_tx_outputs_size = coinbase_output_data_size.m_coinbase_output_max_additional_size;
+
+        break;
+    }
+    default: {
+        uint8_t msg_type[1]{uint8_t(sv2_net_msg.m_msg_type)};
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Warning, "Received unknown message type 0x%s from client id=%zu\n",
+                      HexStr(msg_type), client.m_id);
+        break;
+    }
+    }
+
+    m_msgproc->ReceivedMessage(client, sv2_net_msg.m_msg_type);
+}

--- a/src/common/sv2_connman.cpp
+++ b/src/common/sv2_connman.cpp
@@ -375,6 +375,25 @@ void Sv2Connman::ProcessSv2Message(const Sv2NetMsg& sv2_net_msg, Sv2Client& clie
 
         break;
     }
+    case Sv2MsgType::SUBMIT_SOLUTION: {
+        if (!client.m_setup_connection_confirmed && !client.m_coinbase_output_data_size_recv) {
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        node::Sv2SubmitSolutionMsg submit_solution;
+        try {
+            ss >> submit_solution;
+        } catch (const std::exception& e) {
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Error, "Received invalid SubmitSolution message from client id=%zu: %e\n",
+                          client.m_id, e.what());
+            return;
+        }
+
+        m_msgproc->SubmitSolution(submit_solution);
+
+        break;
+    }
     case Sv2MsgType::REQUEST_TRANSACTION_DATA:
     {
         node::Sv2RequestTransactionDataMsg request_tx_data;

--- a/src/common/sv2_connman.cpp
+++ b/src/common/sv2_connman.cpp
@@ -375,6 +375,22 @@ void Sv2Connman::ProcessSv2Message(const Sv2NetMsg& sv2_net_msg, Sv2Client& clie
 
         break;
     }
+    case Sv2MsgType::REQUEST_TRANSACTION_DATA:
+    {
+        node::Sv2RequestTransactionDataMsg request_tx_data;
+
+        try {
+            ss >> request_tx_data;
+        } catch (const std::exception& e) {
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Error, "Received invalid RequestTransactionData message from client id=%zu: %e\n",
+                          client.m_id, e.what());
+            return;
+        }
+
+        m_msgproc->RequestTransactionData(client, request_tx_data);
+
+        break;
+    }
     default: {
         uint8_t msg_type[1]{uint8_t(sv2_net_msg.m_msg_type)};
         LogPrintLevel(BCLog::SV2, BCLog::Level::Warning, "Received unknown message type 0x%s from client id=%zu\n",

--- a/src/common/sv2_connman.h
+++ b/src/common/sv2_connman.h
@@ -1,0 +1,233 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMMON_SV2_CONNMAN_H
+#define BITCOIN_COMMON_SV2_CONNMAN_H
+
+#include <common/sv2_messages.h>
+#include <common/sv2_transport.h>
+#include <pubkey.h>
+
+namespace {
+    /*
+     * Supported Stratum v2 subprotocols
+     */
+    static constexpr uint8_t TP_SUBPROTOCOL{0x02};
+
+    static const std::map<uint8_t, std::string> SV2_PROTOCOL_NAMES{
+    {0x02, "Template Provider"},
+    };
+}
+
+struct Sv2Client
+{
+    /* Ephemeral identifier for debugging purposes */
+    size_t m_id;
+
+    /**
+     * Receiving and sending socket for the connected client
+     */
+    std::shared_ptr<Sock> m_sock;
+
+    /**
+     * Transport
+     */
+    std::unique_ptr<Sv2Transport> m_transport;
+
+    /**
+     * Whether the client has confirmed the connection with a successful SetupConnection.
+     */
+    bool m_setup_connection_confirmed = false;
+
+    /**
+     * Whether the client is a candidate for disconnection.
+     */
+    bool m_disconnect_flag = false;
+
+    /** Queue of messages to be sent */
+    std::deque<Sv2NetMsg> m_send_messages;
+
+    /**
+     * Whether the client has received CoinbaseOutputDataSize message.
+     */
+    bool m_coinbase_output_data_size_recv = false;
+
+    /**
+     * Specific additional coinbase tx output size required for the client.
+     */
+    unsigned int m_coinbase_tx_outputs_size;
+
+    explicit Sv2Client(size_t id, std::shared_ptr<Sock> sock, std::unique_ptr<Sv2Transport> transport) :
+                       m_id{id}, m_sock{std::move(sock)}, m_transport{std::move(transport)} {};
+
+    bool IsFullyConnected()
+    {
+        return !m_disconnect_flag && m_setup_connection_confirmed;
+    }
+
+    Sv2Client(Sv2Client&) = delete;
+    Sv2Client& operator=(const Sv2Client&) = delete;
+};
+
+/**
+ * Interface for sv2 message handling
+ */
+class Sv2EventsInterface
+{
+public:
+    /**
+    * Generic notification that a message was received. Does not include the
+    * message itself.
+    *
+    * @param[in] client The client which we have received messages from.
+    * @param[in] msg_type the message type
+    */
+    virtual void ReceivedMessage(Sv2Client& client, node::Sv2MsgType msg_type) = 0;
+
+    virtual ~Sv2EventsInterface() = default;
+};
+
+/*
+ * Handle Stratum v2 connections, similar to CConnman.
+ * Currently only supports inbound connections.
+ */
+class Sv2Connman
+{
+private:
+    /** Interface to pass events up */
+    Sv2EventsInterface* m_msgproc;
+
+    /**
+     * The current protocol version of stratum v2 supported by the server. Not to be confused
+     * with byte value of identitying the stratum v2 subprotocol.
+     */
+    const uint16_t m_protocol_version = 2;
+
+    /**
+     * The currently supported optional features.
+     */
+    const uint16_t m_optional_features = 0;
+
+    /**
+     * The subprotocol used in setup connection messages.
+     * An Sv2Connman only recognizes its own subprotocol.
+     */
+    const uint8_t m_subprotocol;
+
+    /**
+     * The main listening socket for new stratum v2 connections.
+     */
+    std::shared_ptr<Sock> m_listening_socket;
+
+    CKey m_static_key;
+
+    XOnlyPubKey m_authority_pubkey;
+
+    std::optional<Sv2SignatureNoiseMessage> m_certificate;
+
+    /**
+     * A list of all connected stratum v2 clients.
+     */
+    using Clients = std::vector<std::unique_ptr<Sv2Client>>;
+    Clients m_sv2_clients GUARDED_BY(m_clients_mutex);
+
+    /**
+     * The main thread for connection handling.
+     */
+    std::thread m_thread_sv2_handler;
+
+    /**
+     * Signal for handling interrupts and stopping the template provider event loop.
+     */
+    std::atomic<bool> m_flag_interrupt_sv2{false};
+    CThreadInterrupt m_interrupt_sv2;
+
+    /**
+     * Creates a socket and binds the port for new stratum v2 connections.
+     * @throws std::runtime_error if port is unable to bind.
+     */
+    [[nodiscard]] std::shared_ptr<Sock> BindListenPort(std::string host, uint16_t port) const;
+
+    void DisconnectFlagged() EXCLUSIVE_LOCKS_REQUIRED(m_clients_mutex);
+
+    /**
+     * The main thread for the template provider, contains an event loop handling
+     * all tasks for the template provider.
+     */
+    void ThreadSv2Handler();
+
+    /**
+     * Generates the socket events for each Sv2Client socket and the main listening socket.
+     */
+    [[nodiscard]] Sock::EventsPerSock GenerateWaitSockets(const std::shared_ptr<Sock>& listen_socket, const Clients& sv2_clients) const;
+
+    /**
+     * Encrypt the header and message payload and send it.
+     * @throws std::runtime_error if encrypting the message fails.
+     */
+    bool EncryptAndSendMessage(Sv2Client& client, node::Sv2NetMsg& net_msg);
+
+    /**
+     * A helper method to read and decrypt multiple Sv2NetMsgs.
+     */
+    std::vector<node::Sv2NetMsg> ReadAndDecryptSv2NetMsgs(Sv2Client& client, Span<std::byte> buffer);
+
+public:
+    Sv2Connman(uint8_t subprotocol, CKey static_key, XOnlyPubKey authority_pubkey, Sv2SignatureNoiseMessage certificate) :
+               m_subprotocol(subprotocol), m_static_key(static_key), m_authority_pubkey(authority_pubkey), m_certificate(certificate) {};
+
+    ~Sv2Connman();
+
+    Mutex m_clients_mutex;
+
+    /**
+     * Starts the Stratum v2 server and thread.
+     * returns false if port is unable to bind.
+     */
+    [[nodiscard]] bool Start(Sv2EventsInterface* msgproc, std::string host, uint16_t port);
+
+    /**
+     * Triggered on interrupt signals to stop the main event loop in ThreadSv2Handler().
+     */
+    void Interrupt();
+
+    /**
+     * Tear down of the connman thread and any other necessary tear down.
+     */
+    void StopThreads();
+
+    /**
+     * Main handler for all received stratum v2 messages.
+     */
+    void ProcessSv2Message(const node::Sv2NetMsg& sv2_header, Sv2Client& client);
+
+    using Sv2ClientFn = std::function<void(Sv2Client&)>;
+    /** Perform a function on each fully connected client. */
+    void ForEachClient(const Sv2ClientFn& func) EXCLUSIVE_LOCKS_REQUIRED(!m_clients_mutex)
+    {
+        LOCK(m_clients_mutex);
+        for (const auto& client : m_sv2_clients) {
+            if (client->IsFullyConnected()) func(*client);
+        }
+    };
+
+    /** Number of clients that are not marked for disconnection, used for tests. */
+    size_t ConnectedClients() EXCLUSIVE_LOCKS_REQUIRED(m_clients_mutex)
+    {
+        return std::count_if(m_sv2_clients.begin(), m_sv2_clients.end(), [](const auto& c) {
+            return !c->m_disconnect_flag;
+        });
+    }
+
+    /** Number of clients with m_setup_connection_confirmed, used for tests. */
+    size_t FullyConnectedClients() EXCLUSIVE_LOCKS_REQUIRED(m_clients_mutex)
+    {
+        return std::count_if(m_sv2_clients.begin(), m_sv2_clients.end(), [](const auto& c) {
+            return c->IsFullyConnected();
+        });
+    }
+
+};
+
+#endif // BITCOIN_COMMON_SV2_CONNMAN_H

--- a/src/common/sv2_connman.h
+++ b/src/common/sv2_connman.h
@@ -152,8 +152,8 @@ private:
     void DisconnectFlagged() EXCLUSIVE_LOCKS_REQUIRED(m_clients_mutex);
 
     /**
-     * The main thread for the template provider, contains an event loop handling
-     * all tasks for the template provider.
+     * The main thread for the connection manager, contains an event loop handling
+     * all tasks for it.
      */
     void ThreadSv2Handler();
 

--- a/src/common/sv2_connman.h
+++ b/src/common/sv2_connman.h
@@ -92,6 +92,11 @@ public:
      */
     virtual void RequestTransactionData(Sv2Client& client, node::Sv2RequestTransactionDataMsg msg) = 0;
 
+    /**
+     * We received and successfully parsed a SubmitSolution message.
+     */
+    virtual void SubmitSolution(node::Sv2SubmitSolutionMsg solution) = 0;
+
     virtual ~Sv2EventsInterface() = default;
 };
 

--- a/src/common/sv2_connman.h
+++ b/src/common/sv2_connman.h
@@ -85,6 +85,13 @@ public:
     */
     virtual void ReceivedMessage(Sv2Client& client, node::Sv2MsgType msg_type) = 0;
 
+    /**
+     * We received and successfully parsed a RequestTransactionData message.
+     * Deal with it and respond with either RequestTransactionData.Success or
+     * RequestTransactionData.Error.
+     */
+    virtual void RequestTransactionData(Sv2Client& client, node::Sv2RequestTransactionDataMsg msg) = 0;
+
     virtual ~Sv2EventsInterface() = default;
 };
 

--- a/src/common/sv2_messages.cpp
+++ b/src/common/sv2_messages.cpp
@@ -1,0 +1,41 @@
+#include <common/sv2_messages.h>
+
+#include <arith_uint256.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+
+node::Sv2NewTemplateMsg::Sv2NewTemplateMsg(const CBlockHeader& header, const CTransactionRef coinbase_tx, std::vector<uint256> coinbase_merkle_path, int witness_commitment_index, uint64_t template_id, bool future_template)
+    : m_template_id{template_id}, m_future_template{future_template}
+{
+    m_version = header.nVersion;
+
+    m_coinbase_tx_version = coinbase_tx->CURRENT_VERSION;
+    m_coinbase_prefix = coinbase_tx->vin[0].scriptSig;
+    m_coinbase_tx_input_sequence = coinbase_tx->vin[0].nSequence;
+
+    // The coinbase nValue already contains the nFee + the Block Subsidy when built using CreateBlock().
+    m_coinbase_tx_value_remaining = static_cast<uint64_t>(coinbase_tx->vout[0].nValue);
+
+    m_coinbase_tx_outputs_count = 0;
+    if (witness_commitment_index != NO_WITNESS_COMMITMENT) {
+        m_coinbase_tx_outputs_count = 1;
+
+        std::vector<CTxOut> coinbase_tx_outputs{coinbase_tx->vout[witness_commitment_index]};
+        m_coinbase_tx_outputs = coinbase_tx_outputs;
+    }
+
+    m_coinbase_tx_locktime = coinbase_tx->nLockTime;
+
+    for (const auto& hash : coinbase_merkle_path) {
+        m_merkle_path.push_back(hash);
+    }
+
+}
+
+node::Sv2SetNewPrevHashMsg::Sv2SetNewPrevHashMsg(const CBlockHeader& header, uint64_t template_id) : m_template_id{template_id}
+{
+    m_prev_hash = header.hashPrevBlock;
+    m_header_timestamp = header.nTime;
+    m_nBits = header.nBits;
+    m_target = ArithToUint256(arith_uint256().SetCompact(header.nBits));
+}

--- a/src/common/sv2_messages.h
+++ b/src/common/sv2_messages.h
@@ -38,6 +38,13 @@ enum class Sv2MsgType : uint8_t {
     COINBASE_OUTPUT_DATA_SIZE = 0x70,
 };
 
+static const std::map<Sv2MsgType, std::string> SV2_MSG_NAMES{
+    {Sv2MsgType::SETUP_CONNECTION, "SetupConnection"},
+    {Sv2MsgType::SETUP_CONNECTION_SUCCESS, "SetupConnectionSuccess"},
+    {Sv2MsgType::SETUP_CONNECTION_ERROR, "SetupConnectionError"},
+    {Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE, "CoinbaseOutputDataSize"},
+};
+
 struct Sv2SetupConnectionMsg
 {
     /**

--- a/src/common/sv2_messages.h
+++ b/src/common/sv2_messages.h
@@ -1,0 +1,171 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMMON_SV2_MESSAGES_H
+#define BITCOIN_COMMON_SV2_MESSAGES_H
+
+#include <span.h>
+#include <streams.h>
+#include <string>
+namespace node {
+/**
+ * A type used as the message length field in stratum v2 messages.
+ */
+using u24_t = uint8_t[3];
+
+/**
+ * All the stratum v2 message types handled by the template provider.
+ */
+enum class Sv2MsgType : uint8_t {
+    COINBASE_OUTPUT_DATA_SIZE = 0x70,
+};
+
+/**
+ * Set the coinbase outputs data len for the outputs that the client wants to add to the coinbase.
+ * The template provider MUST NOT provide NewWork messages which would represent consensus-invalid blocks once this
+ * additional size — along with a maximally-sized (100 byte) coinbase field — is added.
+ */
+struct Sv2CoinbaseOutputDataSizeMsg
+{
+    /**
+     * The default message type value for this Stratum V2 message.
+     */
+    static constexpr auto m_msg_type = Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE;
+
+    /**
+     * The maximum additional serialized bytes which the pool will add in coinbase transaction outputs.
+     */
+    uint32_t m_coinbase_output_max_additional_size;
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s << m_coinbase_output_max_additional_size;
+    };
+
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        s >> m_coinbase_output_max_additional_size;
+    }
+};
+
+/**
+ * Header for all stratum v2 messages. Each header must contain the message type,
+ * the length of the serialized message and a 2 byte extension field currently
+ * not utilised by the template provider.
+ */
+class Sv2NetHeader
+{
+public:
+    /**
+     * Unique identifier of the message.
+     */
+    Sv2MsgType m_msg_type;
+
+    /**
+     * Serialized length of the message.
+     */
+    uint32_t m_msg_len;
+
+    Sv2NetHeader() = default;
+    explicit Sv2NetHeader(Sv2MsgType msg_type, uint32_t msg_len) : m_msg_type{msg_type}, m_msg_len{msg_len} {};
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        // The template provider currently does not use the extension_type field,
+        // but the field is still required for all headers.
+        uint16_t extension_type = 0;
+
+        u24_t msg_len;
+        msg_len[2] = (m_msg_len >> 16) & 0xff;
+        msg_len[1] = (m_msg_len >> 8) & 0xff;
+        msg_len[0] = m_msg_len & 0xff;
+
+        s << extension_type
+          << static_cast<uint8_t>(m_msg_type)
+          << msg_len;
+    };
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        // Ignore the first 2 bytes (extension type) as the template provider currently doesn't
+        // interpret this field.
+        s.ignore(2);
+
+        uint8_t msg_type;
+        s >> msg_type;
+        m_msg_type = static_cast<Sv2MsgType>(msg_type);
+
+        u24_t msg_len_bytes;
+        for (unsigned int i = 0; i < sizeof(u24_t); ++i) {
+            s >> msg_len_bytes[i];
+        }
+
+        m_msg_len = msg_len_bytes[2];
+        m_msg_len = m_msg_len << 8 | msg_len_bytes[1];
+        m_msg_len = m_msg_len << 8 | msg_len_bytes[0];
+    }
+};
+
+/**
+ * The networked form for all stratum v2 messages, contains a header and a serialized
+ * payload from a referenced stratum v2 message.
+ */
+class Sv2NetMsg
+{
+public:
+    Sv2MsgType m_msg_type;
+    std::vector<uint8_t> m_msg;
+
+    explicit Sv2NetMsg(const Sv2MsgType msg_type, const std::vector<uint8_t>&& msg) : m_msg_type{msg_type}, m_msg{msg} {};
+
+    /**
+     * Serializes the message M and sets an Sv2 network header.
+     * @throws std::ios_base or std::out_of_range errors.
+     */
+    template <typename M>
+    explicit Sv2NetMsg(const M& msg)
+    {
+        m_msg_type = msg.m_msg_type;
+
+        // Serialize the sv2 message.
+        VectorWriter{m_msg, 0, msg};
+    }
+
+    unsigned char* data() { return m_msg.data(); }
+    size_t size() { return m_msg.size(); }
+
+    operator Sv2NetHeader()
+    {
+        Sv2NetHeader hdr;
+        hdr.m_msg_type = m_msg_type;
+        hdr.m_msg_len = static_cast<uint32_t>(m_msg.size());
+        return hdr;
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        uint8_t msg_type;
+        s >> msg_type;
+        m_msg_type = static_cast<Sv2MsgType>(msg_type);
+        s.read(MakeWritableByteSpan(m_msg));
+    }
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s << static_cast<uint8_t>(m_msg_type);
+        s.write(MakeByteSpan(m_msg));
+    }
+
+};
+
+}
+
+#endif // BITCOIN_COMMON_SV2_MESSAGES_H

--- a/src/common/sv2_noise.cpp
+++ b/src/common/sv2_noise.cpp
@@ -1,0 +1,528 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/sv2_noise.h>
+
+#include <crypto/chacha20poly1305.h>
+#include <crypto/hmac_sha256.h>
+#include <logging.h>
+#include <util/check.h>
+#include <util/strencodings.h>
+#include <util/time.h>
+
+Sv2SignatureNoiseMessage::Sv2SignatureNoiseMessage(uint16_t version, uint32_t valid_from, uint32_t valid_to, const XOnlyPubKey& static_key, const CKey& authority_key) : m_version{version}, m_valid_from{valid_from}, m_valid_to{valid_to}, m_static_key{static_key}
+{
+    SignSchnorr(authority_key, m_sig);
+}
+
+uint256 Sv2SignatureNoiseMessage::GetHash()
+{
+    DataStream ss{};
+    ss << m_version
+       << m_valid_from
+       << m_valid_to
+       << m_static_key;
+
+    LogTrace(BCLog::SV2, "Certificate hashed data: %s\n", HexStr(ss));
+
+    CSHA256 hasher;
+    hasher.Write(reinterpret_cast<unsigned char*>(&(*ss.begin())), ss.end() - ss.begin());
+
+    uint256 hash_output;
+    hasher.Finalize(hash_output.begin());
+    return hash_output;
+}
+
+bool Sv2SignatureNoiseMessage::Validate(XOnlyPubKey authority_key)
+{
+    if (m_version > 0) {
+        LogTrace(BCLog::SV2, "Invalid certificate version: %d\n", m_version);
+        return false;
+    }
+    auto now{GetTime<std::chrono::seconds>()};
+    if (std::chrono::seconds{m_valid_from} > now) {
+        LogTrace(BCLog::SV2, "Certificate valid from is in the future: %d\n", m_valid_from);
+        return false;
+    }
+    if (std::chrono::seconds{m_valid_to} < now) {
+        LogTrace(BCLog::SV2, "Certificate expired: %d\n", m_valid_to);
+        return false;
+    }
+
+    if (!authority_key.VerifySchnorr(this->GetHash(), m_sig)) {
+        LogTrace(BCLog::SV2, "Certificate signature is invalid\n");
+        return false;
+    }
+    return true;
+}
+
+void Sv2SignatureNoiseMessage::SignSchnorr(const CKey& authority_key, Span<unsigned char> sig)
+{
+    authority_key.SignSchnorr(this->GetHash(), sig, nullptr, {});
+}
+
+Sv2CipherState::Sv2CipherState(uint8_t key[HASHLEN])
+{
+    std::copy(key, key + HASHLEN, m_key);
+}
+
+bool Sv2CipherState::DecryptWithAd(Span<const std::byte> associated_data, Span<std::byte> ciphertext, Span<std::byte> plain)
+{
+    Assume(Sv2Cipher::EncryptedMessageSize(plain.size()) == ciphertext.size());
+
+    if (m_nonce == UINT64_MAX) {
+        // This nonce value is reserved, see chapter 5.1 of the Noise paper.
+        LogTrace(BCLog::SV2, "Nonce exceeds maximum value\n");
+        return false;
+    }
+    AEADChaCha20Poly1305::Nonce96 nonce = {0, m_nonce};
+    auto key = MakeByteSpan(m_key);
+    AEADChaCha20Poly1305 aead{key};
+    if (!aead.Decrypt(ciphertext, associated_data, nonce, plain)) {
+        LogTrace(BCLog::SV2, "Message decryption failed\n");
+        return false;
+    }
+    // Only increase nonce if decryption succeeded
+    m_nonce++;
+    return true;
+}
+
+bool Sv2CipherState::EncryptWithAd(Span<const std::byte> associated_data, Span<const std::byte> plain, Span<std::byte> ciphertext)
+{
+    Assume(Sv2Cipher::EncryptedMessageSize(plain.size()) == ciphertext.size());
+
+    if (m_nonce == UINT64_MAX) {
+        // This nonce value is reserved, see chapter 5.1 of the Noise paper.
+        LogTrace(BCLog::SV2, "Nonce exceeds maximum value\n");
+        return false;
+    }
+    AEADChaCha20Poly1305::Nonce96 nonce = {0, m_nonce++};
+    auto key = MakeByteSpan(m_key);
+    AEADChaCha20Poly1305 aead{key};
+    aead.Encrypt(plain, associated_data, nonce, ciphertext);
+    return true;
+}
+
+bool Sv2CipherState::EncryptMessage(Span<const std::byte> plain, Span<std::byte> ciphertext)
+{
+    Assume(ciphertext.size() == Sv2Cipher::EncryptedMessageSize(plain.size()));
+
+    std::vector<std::byte> ad; // No associated data
+
+    const size_t max_chunk_size = NOISE_MAX_CHUNK_SIZE - Poly1305::TAGLEN;
+    size_t num_chunks = plain.size() / max_chunk_size;
+    if (plain.size() % max_chunk_size != 0) {
+        num_chunks++;
+    }
+    if (num_chunks > 1) {
+        LogTrace(BCLog::SV2,
+                 "Split into %d chunks (max %d bytes)\n",
+                 num_chunks, max_chunk_size);
+    }
+
+    // Copy input bytes into output buffer
+    const std::vector<std::byte> padding(Poly1305::TAGLEN, std::byte(0));
+    for (size_t i = 0; i < num_chunks; ++i) {
+        size_t chunk_start = i * max_chunk_size;
+        size_t chunk_end = std::min(chunk_start + max_chunk_size, plain.size());
+        size_t chunk_size = chunk_end - chunk_start;
+        const auto encrypted_chunk_start = ciphertext.begin() + i * NOISE_MAX_CHUNK_SIZE;
+        std::copy(plain.begin() + chunk_start, plain.begin() + chunk_start + chunk_size, encrypted_chunk_start);
+        std::copy(padding.begin(), padding.end(), encrypted_chunk_start + chunk_size);
+    }
+
+    // Encrypt each chunk
+    size_t bytes_written = 0;
+    for (size_t i = 0; i < num_chunks; ++i) {
+        size_t chunk_size = std::min(ciphertext.size() - bytes_written, NOISE_MAX_CHUNK_SIZE);
+        Span<std::byte> chunk = ciphertext.subspan(bytes_written, chunk_size);
+        Span<std::byte> chunk_plain = ciphertext.subspan(bytes_written, chunk_size - Poly1305::TAGLEN);
+        if (!EncryptWithAd(ad, chunk_plain, chunk)) {
+            return false;
+        }
+        bytes_written += chunk.size();
+    }
+
+    Assume(bytes_written == ciphertext.size());
+    return true;
+}
+
+bool Sv2CipherState::DecryptMessage(Span<std::byte> ciphertext, Span<std::byte> plain)
+{
+    Assume(Sv2Cipher::EncryptedMessageSize(plain.size()) == ciphertext.size());
+
+    size_t processed = 0;
+    size_t plain_position = 0;
+    std::vector<std::byte> ad; // No associated data
+
+    while (processed < ciphertext.size()) {
+        size_t chunk_size = std::min(ciphertext.size() - processed, NOISE_MAX_CHUNK_SIZE);
+        Span<std::byte> chunk_cipher = ciphertext.subspan(processed, chunk_size);
+        Span<std::byte> chunk_plain = plain.subspan(plain_position, chunk_size - Poly1305::TAGLEN);
+        if (!DecryptWithAd(ad, chunk_cipher, chunk_plain)) return false;
+        processed += chunk_size;
+        plain_position += chunk_size - Poly1305::TAGLEN;
+    }
+
+    return true;
+}
+
+void Sv2SymmetricState::MixHash(const Span<const std::byte> input)
+{
+    m_hash_output = (HashWriter{} << m_hash_output << input).GetSHA256();
+}
+
+void Sv2SymmetricState::MixKey(const Span<const std::byte> input_key_material)
+{
+    uint8_t out0[Sv2CipherState::HASHLEN], out1[Sv2CipherState::HASHLEN];
+
+    HKDF2(input_key_material, out0, out1);
+
+    std::memset(m_chaining_key, 0, sizeof(m_chaining_key));
+    std::copy(out0, out0 + Sv2CipherState::HASHLEN, m_chaining_key);
+    m_cipher_state = Sv2CipherState{out1};
+}
+
+std::string Sv2SymmetricState::GetChainingKey()
+{
+    return HexStr(m_chaining_key);
+}
+
+void Sv2SymmetricState::LogChainingKey()
+{
+    LogTrace(BCLog::SV2, "Chaining key: %s\n", GetChainingKey());
+}
+
+void Sv2SymmetricState::HKDF2(const Span<const std::byte> input_key_material, uint8_t out0[Sv2CipherState::HASHLEN], uint8_t out1[Sv2CipherState::HASHLEN])
+{
+    uint8_t tmp_key[Sv2CipherState::HASHLEN];
+    CHMAC_SHA256 tmp_mac(m_chaining_key, Sv2CipherState::HASHLEN);
+    tmp_mac.Write(UCharCast(input_key_material.data()), input_key_material.size());
+    tmp_mac.Finalize(tmp_key);
+
+    CHMAC_SHA256 out0_mac(tmp_key, Sv2CipherState::HASHLEN);
+    uint8_t one[1]{0x1};
+    out0_mac.Write(one, 1);
+    out0_mac.Finalize(out0);
+
+    std::vector<uint8_t> in1;
+    in1.reserve(Sv2CipherState::HASHLEN + 1);
+    std::copy(out0, out0 + Sv2CipherState::HASHLEN, std::back_inserter(in1));
+    in1.push_back(0x02);
+
+    CHMAC_SHA256 out1_mac(tmp_key, Sv2CipherState::HASHLEN);
+    out1_mac.Write(&in1[0], in1.size());
+    out1_mac.Finalize(out1);
+}
+
+bool Sv2SymmetricState::EncryptAndHash(Span<const std::byte> plain, Span<std::byte> ciphertext)
+{
+    Assume(Sv2Cipher::EncryptedMessageSize(plain.size()) == ciphertext.size());
+
+    if (!m_cipher_state.EncryptWithAd(MakeByteSpan(m_hash_output), plain, ciphertext)) {
+        return false;
+    }
+    MixHash(ciphertext);
+    return true;
+}
+
+bool Sv2SymmetricState::DecryptAndHash(Span<std::byte> ciphertext, Span<std::byte> plain)
+{
+    Assume(Sv2Cipher::EncryptedMessageSize(plain.size()) == ciphertext.size());
+
+    // The handshake requires mix hashing the cipher text NOT the decrypted
+    // plaintext.
+    std::vector<std::byte> ciphertext_copy;
+    ciphertext_copy.assign(ciphertext.begin(), ciphertext.end());
+
+    bool res = m_cipher_state.DecryptWithAd(MakeByteSpan(m_hash_output), ciphertext, plain);
+    if (!res) return false;
+    MixHash(ciphertext_copy);
+    return true;
+}
+
+std::array<Sv2CipherState, 2> Sv2SymmetricState::Split()
+{
+    uint8_t send_key[Sv2CipherState::HASHLEN], recv_key[Sv2CipherState::HASHLEN];
+
+    std::vector<std::byte> empty;
+    HKDF2(empty, send_key, recv_key);
+
+    std::array<Sv2CipherState, 2> result;
+    result[0] = Sv2CipherState{send_key};
+    result[1] = Sv2CipherState{recv_key};
+
+    return result;
+}
+
+uint256 Sv2SymmetricState::GetHashOutput()
+{
+    return m_hash_output;
+}
+
+void Sv2HandshakeState::SetEphemeralKey(CKey&& key)
+{
+    m_ephemeral_key = key;
+    m_ephemeral_ellswift_pk = m_ephemeral_key.EllSwiftCreate(MakeByteSpan(GetRandHash()));
+};
+
+void Sv2HandshakeState::GenerateEphemeralKey() noexcept
+{
+    Assume(!m_ephemeral_key.size());
+    LogTrace(BCLog::SV2, "Generate ephemeral key\n");
+    SetEphemeralKey(GenerateRandomKey());
+};
+
+void Sv2HandshakeState::WriteMsgEphemeralPK(Span<std::byte> msg)
+{
+    if (msg.size() < ELLSWIFT_PUB_KEY_SIZE) {
+        throw std::runtime_error(strprintf("Invalid message size: %d bytes < %d", msg.size(), ELLSWIFT_PUB_KEY_SIZE));
+    }
+
+    if (!m_ephemeral_key.IsValid()) {
+        GenerateEphemeralKey();
+    }
+
+    LogTrace(BCLog::SV2, "Write our ephemeral key\n");
+    std::copy(m_ephemeral_ellswift_pk.begin(), m_ephemeral_ellswift_pk.end(), msg.begin());
+
+    m_symmetric_state.MixHash(msg.subspan(0, ELLSWIFT_PUB_KEY_SIZE));
+    LogTrace(BCLog::SV2, "Mix hash: %s\n", HexStr(m_symmetric_state.GetHashOutput()));
+
+    std::vector<std::byte> empty;
+    m_symmetric_state.MixHash(empty);
+}
+
+void Sv2HandshakeState::ReadMsgEphemeralPK(Span<std::byte> msg)
+{
+    LogTrace(BCLog::SV2, "Read their ephemeral key\n");
+    Assume(msg.size() == ELLSWIFT_PUB_KEY_SIZE);
+    m_remote_ephemeral_ellswift_pk = EllSwiftPubKey(msg);
+
+    m_symmetric_state.MixHash(msg.subspan(0, ELLSWIFT_PUB_KEY_SIZE));
+    LogTrace(BCLog::SV2, "Mix hash: %s\n", HexStr(m_symmetric_state.GetHashOutput()));
+
+    std::vector<std::byte> empty;
+    m_symmetric_state.MixHash(empty);
+}
+
+void Sv2HandshakeState::WriteMsgES(Span<std::byte> msg)
+{
+    if (msg.size() < HANDSHAKE_STEP2_SIZE) {
+        throw std::runtime_error(strprintf("Invalid message size: %d bytes < %d", msg.size(), HANDSHAKE_STEP2_SIZE));
+    }
+
+    ssize_t bytes_written = 0;
+
+    if (!m_ephemeral_key.IsValid()) {
+        GenerateEphemeralKey();
+    }
+
+    // Send our ephemeral pk.
+    LogTrace(BCLog::SV2, "Write our ephemeral key\n");
+    std::copy(m_ephemeral_ellswift_pk.begin(), m_ephemeral_ellswift_pk.end(), msg.begin());
+
+    m_symmetric_state.MixHash(msg.subspan(0, ELLSWIFT_PUB_KEY_SIZE));
+    bytes_written += ELLSWIFT_PUB_KEY_SIZE;
+
+    LogTrace(BCLog::SV2, "Mix hash: %s\n", HexStr(m_symmetric_state.GetHashOutput()));
+
+    LogTrace(BCLog::SV2, "Perform ECDH with the remote ephemeral key\n");
+    ECDHSecret ecdh_secret{m_ephemeral_key.ComputeBIP324ECDHSecret(m_remote_ephemeral_ellswift_pk,
+                                                                   m_ephemeral_ellswift_pk,
+                                                                   /*initiating=*/false)};
+
+    LogTrace(BCLog::SV2, "Mix key with ECDH result: ephemeral ours -- remote ephemeral\n");
+    m_symmetric_state.MixKey(ecdh_secret);
+    m_symmetric_state.LogChainingKey();
+
+    // Send our static pk.
+    LogTrace(BCLog::SV2, "Encrypt and write our static key\n");
+
+    if (!m_symmetric_state.EncryptAndHash(m_static_ellswift_pk, msg.subspan(ELLSWIFT_PUB_KEY_SIZE, ELLSWIFT_PUB_KEY_SIZE + Poly1305::TAGLEN))) {
+        // This should never happen
+        Assume(false);
+        throw std::runtime_error("Failed to encrypt our ephemeral key\n");
+    }
+
+    bytes_written += ELLSWIFT_PUB_KEY_SIZE + Poly1305::TAGLEN;
+
+    LogTrace(BCLog::SV2, "Mix hash: %s\n", HexStr(m_symmetric_state.GetHashOutput()));
+
+    LogTrace(BCLog::SV2, "Perform ECDH between our static and remote ephemeral key\n");
+    ECDHSecret ecdh_static_secret{m_static_key.ComputeBIP324ECDHSecret(m_remote_ephemeral_ellswift_pk,
+                                                                       m_static_ellswift_pk,
+                                                                       /*initiating=*/false)};
+    LogTrace(BCLog::SV2, "ECDH result: %s\n", HexStr(ecdh_static_secret));
+
+    LogTrace(BCLog::SV2, "Mix key with ECDH result: static ours -- remote ephemeral\n");
+    m_symmetric_state.MixKey(ecdh_static_secret);
+    m_symmetric_state.LogChainingKey();
+
+    // Serialize our digital signature noise message and encrypt.
+    DataStream ss{};
+    Assume(m_certificate);
+    ss << m_certificate.value();
+    Assume(ss.size() == Sv2SignatureNoiseMessage::SIZE);
+
+    LogTrace(BCLog::SV2, "Encrypt certificate: %s\n", HexStr(ss));
+    if (!m_symmetric_state.EncryptAndHash(ss, msg.subspan(bytes_written, Sv2SignatureNoiseMessage::SIZE + Poly1305::TAGLEN))) {
+        // This should never happen
+        Assume(false);
+        throw std::runtime_error("Failed to encrypt our certificate\n");
+    }
+
+    LogTrace(BCLog::SV2, "Mix hash: %s\n", HexStr(m_symmetric_state.GetHashOutput()));
+
+    bytes_written += Sv2SignatureNoiseMessage::SIZE + Poly1305::TAGLEN;
+    Assume(bytes_written == HANDSHAKE_STEP2_SIZE);
+}
+
+bool Sv2HandshakeState::ReadMsgES(Span<std::byte> msg)
+{
+    Assume(msg.size() == HANDSHAKE_STEP2_SIZE);
+    ssize_t bytes_read = 0;
+
+    // Read the remote ephmeral key from the msg and decrypt.
+    LogTrace(BCLog::SV2, "Read remote ephemeral key\n");
+    m_remote_ephemeral_ellswift_pk = EllSwiftPubKey(msg.subspan(0, ELLSWIFT_PUB_KEY_SIZE));
+    bytes_read += ELLSWIFT_PUB_KEY_SIZE;
+
+    m_symmetric_state.MixHash(m_remote_ephemeral_ellswift_pk);
+    LogTrace(BCLog::SV2, "Mix hash: %s\n", HexStr(m_symmetric_state.GetHashOutput()));
+
+    LogTrace(BCLog::SV2, "Perform ECDH with the remote ephemeral key\n");
+    ECDHSecret ecdh_secret{m_ephemeral_key.ComputeBIP324ECDHSecret(m_remote_ephemeral_ellswift_pk,
+                                                                   m_ephemeral_ellswift_pk,
+                                                                   /*initiating=*/true)};
+
+    LogTrace(BCLog::SV2, "Mix key with ECDH result: ephemeral ours -- remote ephemeral\n");
+    m_symmetric_state.MixKey(ecdh_secret);
+    m_symmetric_state.LogChainingKey();
+
+    LogTrace(BCLog::SV2, "Decrypt remote static key\n");
+    std::array<std::byte, ELLSWIFT_PUB_KEY_SIZE> remote_static_key_bytes;
+    bool res = m_symmetric_state.DecryptAndHash(msg.subspan(ELLSWIFT_PUB_KEY_SIZE, ELLSWIFT_PUB_KEY_SIZE + Poly1305::TAGLEN), remote_static_key_bytes);
+    if (!res) return false;
+    bytes_read += ELLSWIFT_PUB_KEY_SIZE + Poly1305::TAGLEN;
+
+    LogTrace(BCLog::SV2, "Mix hash: %s\n", HexStr(m_symmetric_state.GetHashOutput()));
+
+    // Load remote static key from the decryted msg
+    m_remote_static_ellswift_pk = EllSwiftPubKey(remote_static_key_bytes);
+
+    LogTrace(BCLog::SV2, "Perform ECDH on the remote static key\n");
+    ECDHSecret ecdh_static_secret{m_ephemeral_key.ComputeBIP324ECDHSecret(m_remote_static_ellswift_pk,
+                                                                          m_ephemeral_ellswift_pk,
+                                                                          /*initiating=*/true)};
+    LogTrace(BCLog::SV2, "ECDH result: %s\n", HexStr(ecdh_static_secret));
+
+    LogTrace(BCLog::SV2, "Mix key with ECDH result: ephemeral ours -- remote static\n");
+    m_symmetric_state.MixKey(ecdh_static_secret);
+    m_symmetric_state.LogChainingKey();
+
+    LogTrace(BCLog::SV2, "Decrypt remote certificate\n");
+    std::array<std::byte, Sv2SignatureNoiseMessage::SIZE> remote_cert_bytes;
+    res = m_symmetric_state.DecryptAndHash(msg.subspan(bytes_read, Sv2SignatureNoiseMessage::SIZE + Poly1305::TAGLEN), remote_cert_bytes);
+    if (!res) return false;
+    bytes_read += (Sv2SignatureNoiseMessage::SIZE + Poly1305::TAGLEN);
+
+    LogTrace(BCLog::SV2, "Validate remote certificate\n");
+    DataStream ss_cert(remote_cert_bytes);
+    Sv2SignatureNoiseMessage cert;
+    ss_cert >> cert;
+    cert.m_static_key = XOnlyPubKey(m_remote_static_ellswift_pk.Decode());
+    Assume(m_authority_pubkey);
+    if (!cert.Validate(m_authority_pubkey.value())) {
+        // We initiated the connection, so it's safe to unconditionally log this:
+        LogWarning("Invalid certificate: %s\n", HexStr(remote_cert_bytes));
+        return false;
+    }
+
+    LogTrace(BCLog::SV2, "Mix hash: %s\n", HexStr(m_symmetric_state.GetHashOutput()));
+
+    Assume(bytes_read == HANDSHAKE_STEP2_SIZE);
+    return true;
+}
+
+std::array<Sv2CipherState, 2> Sv2HandshakeState::SplitSymmetricState()
+{
+    return m_symmetric_state.Split();
+}
+
+uint256 Sv2HandshakeState::GetHashOutput()
+{
+    return m_symmetric_state.GetHashOutput();
+}
+
+Sv2Cipher::Sv2Cipher(CKey&& static_key, XOnlyPubKey authority_pubkey)
+{
+    m_handshake_state = std::make_unique<Sv2HandshakeState>(std::move(static_key), authority_pubkey);
+    m_initiator = true;
+}
+
+Sv2Cipher::Sv2Cipher(CKey&& static_key, Sv2SignatureNoiseMessage&& certificate)
+{
+    m_handshake_state = std::make_unique<Sv2HandshakeState>(std::move(static_key), std::move(certificate));
+    m_initiator = false;
+}
+
+Sv2HandshakeState& Sv2Cipher::GetHandshakeState()
+{
+    Assume(m_handshake_state);
+    return *m_handshake_state;
+}
+
+void Sv2Cipher::FinishHandshake()
+{
+    Assume(m_handshake_state);
+
+    auto cipher_state = m_handshake_state->SplitSymmetricState();
+    auto cs1 = cipher_state[0];
+    auto cs2 = cipher_state[1];
+
+    m_hash = m_handshake_state->GetHashOutput();
+
+    m_cs1 = std::move(cs1);
+    m_cs2 = std::move(cs2);
+
+    m_handshake_state.reset();
+}
+
+size_t Sv2Cipher::EncryptedMessageSize(size_t msg_len)
+{
+    size_t num_chunks = msg_len / (NOISE_MAX_CHUNK_SIZE - Poly1305::TAGLEN);
+    if (msg_len % (NOISE_MAX_CHUNK_SIZE - Poly1305::TAGLEN) != 0) {
+        num_chunks++;
+    }
+    return msg_len + (num_chunks * Poly1305::TAGLEN);
+}
+
+bool Sv2Cipher::DecryptMessage(Span<std::byte> ciphertext, Span<std::byte> plain)
+{
+    Assume(EncryptedMessageSize(plain.size()) == ciphertext.size());
+
+    if (m_initiator) {
+        return m_cs2.DecryptMessage(ciphertext, plain);
+    } else {
+        return m_cs1.DecryptMessage(ciphertext, plain);
+    }
+}
+
+bool Sv2Cipher::EncryptMessage(Span<const std::byte> input, Span<std::byte> output)
+{
+    Assume(output.size() == Sv2Cipher::EncryptedMessageSize(input.size()));
+
+    if (m_initiator) {
+        if (!m_cs1.EncryptMessage(input, output)) return false;
+    } else {
+        if (!m_cs2.EncryptMessage(input, output)) return false;
+    }
+    return true;
+}
+
+uint256 Sv2Cipher::GetHash() const
+{
+    return m_hash;
+}

--- a/src/common/sv2_noise.h
+++ b/src/common/sv2_noise.h
@@ -1,0 +1,298 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMMON_SV2_NOISE_H
+#define BITCOIN_COMMON_SV2_NOISE_H
+
+#include <compat/compat.h>
+#include <crypto/poly1305.h>
+#include <key.h>
+#include <pubkey.h>
+#include <random.h>
+#include <streams.h>
+#include <uint256.h>
+
+/** The Noise Protocol Framework
+ *  https://noiseprotocol.org/noise.html
+ *  Revision 38, 2018-07-11
+ *
+ *  Stratum v2 handshake and cipher specification:
+ *  https://github.com/stratum-mining/sv2-spec/blob/main/04-Protocol-Security.md
+ */
+
+/** Section 3: All Noise messages are less than or equal to 65535 bytes in length. */
+static constexpr size_t NOISE_MAX_CHUNK_SIZE = 65535;
+
+/** Simple certificate for the static key signed by the authority key.
+ * See 4.5.2 and 4.5.3 of the Stratum v2 spec.
+ */
+class Sv2SignatureNoiseMessage
+{
+public:
+    /** Size of a Schnorr signature. */
+    static constexpr size_t SCHNORR_SIGNATURE_SIZE = 64;
+    /** Size of serialized message, which does not include the static key.  */
+    static constexpr size_t SIZE = 2 + 4 + 4 + SCHNORR_SIGNATURE_SIZE;
+
+private:
+    uint16_t m_version = 0;
+    uint32_t m_valid_from = 0;
+    uint32_t m_valid_to = 0;
+    std::array<unsigned char, SCHNORR_SIGNATURE_SIZE> m_sig;
+
+    /** Hash of version, valid from/to and the static key. */
+    uint256 GetHash();
+    void SignSchnorr(const CKey& authority_key, Span<unsigned char> sig);
+
+public:
+    Sv2SignatureNoiseMessage() = default;
+    Sv2SignatureNoiseMessage(uint16_t version, uint32_t valid_from, uint32_t valid_to, const XOnlyPubKey& static_key, const CKey& authority_key);
+
+    /* The certificate serializes pubkeys in x-only format, not EllSwift. */
+    XOnlyPubKey m_static_key = {};
+
+    [[nodiscard]] bool Validate(XOnlyPubKey authority_key);
+
+    template <typename Stream>
+    // The static_key is signed for, but not serialized.
+    void Serialize(Stream& s) const
+    {
+        s << m_version
+          << m_valid_from
+          << m_valid_to
+          << m_sig;
+    }
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        s >> m_version
+          >> m_valid_from
+          >> m_valid_to
+          >> m_sig;
+    }
+};
+
+/*
+ * The CipherState uses m_key (k) and m_nonce (n) to encrypt and decrypt ciphertexts.
+ * During the handshake phase each party has a single CipherState, but during
+ * the transport phase each party has two CipherState objects: one for sending,
+ * and one for receiving.
+ *
+ * See chapter "5. Processing rules" of the Noise paper.
+ */
+class Sv2CipherState
+{
+public:
+    static constexpr size_t HASHLEN{32};
+
+    Sv2CipherState() = default;
+    explicit Sv2CipherState(uint8_t key[HASHLEN]);
+
+    /** Decrypt message
+     * @param[in] associated_data associated data
+     * @param[in] ciphertext message with encrypted and authenticated chunks.
+     * @param[out] plain message (defragmented)
+     * @returns whether decryption succeeded
+     */
+    [[nodiscard]] bool DecryptWithAd(Span<const std::byte> associated_data, Span<std::byte> ciphertext, Span<std::byte> plain);
+
+    /** Encrypt message
+     * @param[in] associated_data associated data
+     * @param[in] plain message
+     * @param[out] ciphertext message with encrypted and authenticated chunks.
+     * @returns whether decryption succeeded
+     */
+    [[nodiscard]] bool EncryptWithAd(Span<const std::byte> associated_data, Span<const std::byte> plain, Span<std::byte> ciphertext);
+
+    /** The message will be chunked in NOISE_MAX_CHUNK_SIZE parts and expanded
+     *  by 16 bytes per chunk for its MAC.
+     *
+     * @param[in] plain message. Can't point to the same memory location as ciphertext,
+     *                  because each encrypted message chunk would override the
+     *                  start of the next plain text chunk.
+     * @param[out] ciphertext   message with encrypted and authenticated chunks
+     * @return whether encryption succeeded. Only fails if nonce is uint64_max.
+     */
+    [[nodiscard]] bool EncryptMessage(Span<const std::byte> plain, Span<std::byte> ciphertext);
+
+    /** Decrypt message.
+     *
+     * @param[in] ciphertext encrypted message
+     * @param[out] plain decrypted message. May point to the same memory location
+     *                  as ciphertext. The result is defragmented.
+     */
+    [[nodiscard]] bool DecryptMessage(Span<std::byte> ciphertext, Span<std::byte> plain);
+
+private:
+    uint8_t m_key[HASHLEN];
+    uint64_t m_nonce = 0;
+};
+
+/*
+ * A SymmetricState object contains a CipherState plus m_chaining_key (ck) and
+ * m_hash_output (h) variables. It is so-named because it encapsulates all the
+ * "symmetric crypto" used by Noise. During the handshake phase each party has
+ * a single SymmetricState, which can be deleted once the handshake is finished.
+ *
+ * See chapter "5. Processing rules" of the Noise paper.
+ */
+class Sv2SymmetricState
+{
+public:
+    // Sha256 hash of the ascii encoding - "Noise_NX_Secp256k1+EllSwift_ChaChaPoly_SHA256".
+    // This is the first step required when setting up the chaining key.
+    static constexpr std::array<uint8_t, 32> PROTOCOL_NAME_HASH = {
+        46, 180, 120, 129, 32, 142, 158, 238, 31, 102, 159, 103, 198, 110, 231, 14,
+        169, 234, 136, 9, 13, 80, 63, 232, 48, 220, 75, 200, 62, 41, 191, 16};
+
+    // The double hash of protocol name "Noise_NX_EllSwiftXonly_ChaChaPoly_SHA256".
+    static constexpr std::array<uint8_t, 32> PROTOCOL_NAME_DOUBLE_HASH = {146, 47, 163, 46, 79, 72, 124, 13, 89, 202, 163, 190, 215, 137, 156, 227,
+                                                                          217, 141, 183, 225, 61, 189, 59, 124, 242, 210, 61, 212, 51, 220, 97, 4};
+
+    Sv2SymmetricState()
+    {
+        std::memcpy(m_chaining_key, PROTOCOL_NAME_HASH.data(), PROTOCOL_NAME_HASH.size());
+    }
+
+    void MixHash(const Span<const std::byte> input);
+    void MixKey(const Span<const std::byte> input_key_material);
+    [[nodiscard]] bool EncryptAndHash(Span<const std::byte> plain, Span<std::byte> ciphertext);
+    [[nodiscard]] bool DecryptAndHash(Span<std::byte> ciphertext, Span<std::byte> plain);
+    std::array<Sv2CipherState, 2> Split();
+
+    uint256 GetHashOutput();
+
+    /* For testing */
+    void LogChainingKey();
+    std::string GetChainingKey();
+
+private:
+    uint8_t m_chaining_key[Sv2CipherState::HASHLEN];
+    uint256 m_hash_output = uint256(PROTOCOL_NAME_DOUBLE_HASH);
+    Sv2CipherState m_cipher_state;
+
+    void HKDF2(const Span<const std::byte> input_key_material, uint8_t out0[Sv2CipherState::HASHLEN], uint8_t out1[Sv2CipherState::HASHLEN]);
+};
+
+/*
+ * A HandshakeState object contains a SymmetricState plus DH variables (s, e, rs, re)
+ * and a variable representing the handshake pattern. During the handshake phase
+ * each party has a single HandshakeState, which can be deleted once the handshake
+ * is finished.
+ *
+ * See chapter "5. Processing rules" of the Noise paper.
+ */
+
+class Sv2HandshakeState
+{
+public:
+    static constexpr size_t ELLSWIFT_PUB_KEY_SIZE{64};
+    static constexpr size_t ECDH_OUTPUT_SIZE{32};
+
+    static constexpr size_t HANDSHAKE_STEP2_SIZE = ELLSWIFT_PUB_KEY_SIZE + ELLSWIFT_PUB_KEY_SIZE +
+                                                   Poly1305::TAGLEN + Sv2SignatureNoiseMessage::SIZE + Poly1305::TAGLEN;
+
+    /*
+     * If we are the initiator m_authority_pubkey must be set in order to verify
+     * the received certificate.
+     */
+    Sv2HandshakeState(CKey&& static_key,
+                      XOnlyPubKey authority_pubkey) : m_static_key{static_key},
+                                                        m_authority_pubkey{authority_pubkey}
+    {
+        m_static_ellswift_pk = static_key.EllSwiftCreate(MakeByteSpan(GetRandHash()));
+    };
+
+    /*
+     * If we are the responder, the certificate must be set
+     */
+    Sv2HandshakeState(CKey&& static_key,
+                      Sv2SignatureNoiseMessage&& certificate) : m_static_key{static_key},
+                                                                m_certificate{certificate}
+    {
+        m_static_ellswift_pk = static_key.EllSwiftCreate(MakeByteSpan(GetRandHash()));
+    };
+
+    /** Handshake step 1 for initiator: -> e */
+    void WriteMsgEphemeralPK(Span<std::byte> msg);
+    /** Handshake step 1 for responder: -> e */
+    void ReadMsgEphemeralPK(Span<std::byte> msg);
+    /** During handshake step 2, put our ephmeral key, static key
+     * and certificate in the buffer: <- e, ee, s, es, SIGNATURE_NOISE_MESSAGE
+     */
+    void WriteMsgES(Span<std::byte> msg);
+    /** During handshake step 2, read the remote ephmeral key, static key
+     * and certificate. Verify their certificate.
+     * <- e, ee, s, es, SIGNATURE_NOISE_MESSAGE
+     */
+    [[nodiscard]] bool ReadMsgES(Span<std::byte> msg);
+
+    std::array<Sv2CipherState, 2> SplitSymmetricState();
+    uint256 GetHashOutput();
+
+    void SetEphemeralKey(CKey&& key);
+
+private:
+    /** Our static key (s) */
+    CKey m_static_key;
+    /** EllSwift encoded static key, for optimized ECDH */
+    EllSwiftPubKey m_static_ellswift_pk;
+    /** Our ephemeral key (e) */
+    CKey m_ephemeral_key;
+    /** EllSwift encoded ephemeral key, for optimized ECDH */
+    EllSwiftPubKey m_ephemeral_ellswift_pk;
+    /** Remote static key (rs) */
+    EllSwiftPubKey m_remote_static_ellswift_pk;
+    /** Remote ephemeral key (re) */
+    EllSwiftPubKey m_remote_ephemeral_ellswift_pk;
+    Sv2SymmetricState m_symmetric_state;
+    /** Certificate signed by m_authority_pubkey. */
+    std::optional<Sv2SignatureNoiseMessage> m_certificate;
+    /** Authority public key. */
+    std::optional<XOnlyPubKey> m_authority_pubkey;
+
+    /** Generate ephemeral key, sets set m_ephemeral_key and m_ephemeral_ellswift_pk */
+    void GenerateEphemeralKey() noexcept;
+};
+
+/**
+ * Interface somewhat similar to BIP324Cipher for use by a Transport class.
+ * The initiator and responder roles have their own constructor.
+ * FinishHandshake() must be called after all handshake bytes have been processed.
+ */
+class Sv2Cipher
+{
+public:
+    Sv2Cipher(CKey&& static_key, XOnlyPubKey authority_pubkey);
+    Sv2Cipher(CKey&& static_key, Sv2SignatureNoiseMessage&& certificate);
+
+    Sv2Cipher(bool initiator, std::unique_ptr<Sv2HandshakeState> handshake_state) : m_initiator{initiator}, m_handshake_state{std::move(handshake_state)} {};
+
+    Sv2HandshakeState& GetHandshakeState();
+    /**
+     * Populates m_hash, m_cs1 and m_cs2 from m_handshake_state and deletes the latter.
+     */
+    void FinishHandshake();
+
+    /** Decrypts a message. May only be called after FinishHandshake() */
+    bool DecryptMessage(Span<std::byte> ciphertext, Span<std::byte> plain);
+    /** Encrypts a message. May only be called after FinishHandshake() */
+    [[nodiscard]] bool EncryptMessage(Span<const std::byte> input, Span<std::byte> output);
+
+    /* Expected size after chunking and with MAC */
+    static size_t EncryptedMessageSize(size_t msg_len);
+
+    /* Test only */
+    uint256 GetHash() const;
+
+private:
+    bool m_initiator;
+    std::unique_ptr<Sv2HandshakeState> m_handshake_state;
+
+    uint256 m_hash;
+    Sv2CipherState m_cs1;
+    Sv2CipherState m_cs2;
+};
+
+#endif // BITCOIN_COMMON_SV2_NOISE_H

--- a/src/common/sv2_transport.cpp
+++ b/src/common/sv2_transport.cpp
@@ -1,0 +1,494 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/sv2_transport.h>
+
+#include <logging.h>
+#include <memusage.h>
+#include <common/sv2_messages.h>
+#include <common/sv2_noise.h>
+#include <random.h>
+#include <util/check.h>
+#include <util/strencodings.h>
+#include <util/vector.h>
+
+Sv2Transport::Sv2Transport(CKey static_key, Sv2SignatureNoiseMessage certificate) noexcept
+    : m_cipher{Sv2Cipher(std::move(static_key), std::move(certificate))}, m_initiating{false},
+      m_recv_state{RecvState::HANDSHAKE_STEP_1},
+      m_send_state{SendState::HANDSHAKE_STEP_2},
+      m_message{Sv2NetMsg(Sv2NetHeader{})}
+{
+    LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Noise session receive state -> %s\n",
+                    RecvStateAsString(m_recv_state));
+}
+
+Sv2Transport::Sv2Transport(CKey static_key, XOnlyPubKey responder_authority_key) noexcept
+    : m_cipher{Sv2Cipher(std::move(static_key), responder_authority_key)}, m_initiating{true},
+      m_recv_state{RecvState::HANDSHAKE_STEP_2},
+      m_send_state{SendState::HANDSHAKE_STEP_1},
+      m_message{Sv2NetMsg(Sv2NetHeader{})}
+{
+    /** Start sending immediately since we're the initiator of the connection.
+        This only happens in test code.
+    */
+    LOCK(m_send_mutex);
+    StartSendingHandshake();
+
+}
+
+void Sv2Transport::SetReceiveState(RecvState recv_state) noexcept
+{
+    AssertLockHeld(m_recv_mutex);
+    // Enforce allowed state transitions.
+    switch (m_recv_state) {
+    case RecvState::HANDSHAKE_STEP_1:
+        Assume(recv_state == RecvState::HANDSHAKE_STEP_2);
+        break;
+    case RecvState::HANDSHAKE_STEP_2:
+        Assume(recv_state == RecvState::APP);
+        break;
+    case RecvState::APP:
+        Assume(recv_state == RecvState::APP_READY);
+        break;
+    case RecvState::APP_READY:
+        Assume(recv_state == RecvState::APP);
+        break;
+    }
+    // Change state.
+    m_recv_state = recv_state;
+    LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Noise session receive state -> %s\n",
+                  RecvStateAsString(m_recv_state));
+
+}
+
+void Sv2Transport::SetSendState(SendState send_state) noexcept
+{
+    AssertLockHeld(m_send_mutex);
+    // Enforce allowed state transitions.
+    switch (m_send_state) {
+    case SendState::HANDSHAKE_STEP_1:
+        Assume(send_state == SendState::HANDSHAKE_STEP_2);
+        break;
+    case SendState::HANDSHAKE_STEP_2:
+        Assume(send_state == SendState::READY);
+        break;
+    case SendState::READY:
+        Assume(false); // Final state
+        break;
+    }
+    // Change state.
+    m_send_state = send_state;
+    LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Noise session send state -> %s\n",
+                  SendStateAsString(m_send_state));
+}
+
+void Sv2Transport::StartSendingHandshake() noexcept
+{
+    AssertLockHeld(m_send_mutex);
+    AssertLockNotHeld(m_recv_mutex);
+    Assume(m_send_state == SendState::HANDSHAKE_STEP_1);
+    Assume(m_send_buffer.empty());
+
+    m_send_buffer.resize(Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE);
+    m_cipher.GetHandshakeState().WriteMsgEphemeralPK(MakeWritableByteSpan(m_send_buffer));
+
+    m_send_state = SendState::HANDSHAKE_STEP_2;
+}
+
+void Sv2Transport::SendHandshakeReply() noexcept
+{
+    AssertLockHeld(m_send_mutex);
+    AssertLockHeld(m_recv_mutex);
+    Assume(m_send_state == SendState::HANDSHAKE_STEP_2);
+
+    Assume(m_send_buffer.empty());
+    m_send_buffer.resize(Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+    m_cipher.GetHandshakeState().WriteMsgES(MakeWritableByteSpan(m_send_buffer));
+
+    m_cipher.FinishHandshake();
+
+    // We can send and receive stuff now, unless the other side hangs up
+    SetSendState(SendState::READY);
+    Assume(m_recv_state == RecvState::HANDSHAKE_STEP_2);
+    SetReceiveState(RecvState::APP);
+}
+
+Transport::BytesToSend Sv2Transport::GetBytesToSend(bool have_next_message) const noexcept
+{
+    AssertLockNotHeld(m_send_mutex);
+    LOCK(m_send_mutex);
+
+    const std::string dummy_m_type; // m_type is set to "" when wrapping Sv2NetMsg
+
+    Assume(m_send_pos <= m_send_buffer.size());
+    return {
+        Span{m_send_buffer}.subspan(m_send_pos),
+        // We only have more to send after the current m_send_buffer if there is a (next)
+        // message to be sent, and we're capable of sending packets. */
+        have_next_message && m_send_state == SendState::READY,
+        dummy_m_type
+    };
+}
+
+void Sv2Transport::MarkBytesSent(size_t bytes_sent) noexcept
+{
+    AssertLockNotHeld(m_send_mutex);
+    LOCK(m_send_mutex);
+
+    // if (m_send_state == SendState::AWAITING_KEY && m_send_pos == 0 && bytes_sent > 0) {
+    //     LogPrint(BCLog::NET, "start sending v2 handshake to peer=%d\n", m_nodeid);
+    // }
+
+    m_send_pos += bytes_sent;
+    Assume(m_send_pos <= m_send_buffer.size());
+    // Wipe the buffer when everything is sent.
+    if (m_send_pos == m_send_buffer.size()) {
+        m_send_pos = 0;
+        ClearShrink(m_send_buffer);
+    }
+}
+
+bool Sv2Transport::SetMessageToSend(CSerializedNetMsg& msg) noexcept
+{
+    AssertLockNotHeld(m_send_mutex);
+    LOCK(m_send_mutex);
+
+    // We only allow adding a new message to be sent when in the READY state (so the packet cipher
+    // is available) and the send buffer is empty. This limits the number of messages in the send
+    // buffer to just one, and leaves the responsibility for queueing them up to the caller.
+    if (m_send_state != SendState::READY) {
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "SendState is not READY\n");
+        return false;
+    }
+
+    if (!m_send_buffer.empty()) {
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Send buffer is not empty\n");
+        return false;
+    }
+
+    // The Sv2NetMsg is wrapped inside a dummy CSerializedNetMsg, extract it:
+    Sv2NetMsg sv2_msg(std::move(msg));
+    // Reconstruct the header:
+    Sv2NetHeader hdr(sv2_msg.m_msg_type, sv2_msg.size());
+
+    // Construct ciphertext in send buffer.
+    const size_t encrypted_msg_size = Sv2Cipher::EncryptedMessageSize(sv2_msg.size());
+    m_send_buffer.resize(SV2_HEADER_ENCRYPTED_SIZE + encrypted_msg_size);
+    Span<std::byte> buffer_span{MakeWritableByteSpan(m_send_buffer)};
+
+    // Header
+    DataStream ss_header_plain{};
+    ss_header_plain << hdr;
+    LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Header: %s\n", HexStr(ss_header_plain));
+    Span<std::byte> header_encrypted{buffer_span.subspan(0, SV2_HEADER_ENCRYPTED_SIZE)};
+    if (!m_cipher.EncryptMessage(ss_header_plain, header_encrypted)) {
+        return false;
+    }
+
+    // Payload
+    Span<const std::byte> payload_plain = MakeByteSpan(sv2_msg);
+    // TODO: truncate very long messages, about 100 bytes at the start and end
+    //       is probably enough for most debugging.
+    // LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Payload: %s\n", HexStr(payload_plain));
+    Span<std::byte> payload_encrypted{buffer_span.subspan(SV2_HEADER_ENCRYPTED_SIZE, encrypted_msg_size)};
+    if (!m_cipher.EncryptMessage(payload_plain, payload_encrypted)) {
+        return false;
+    }
+
+    // Release memory (not needed with std::move above)
+    // ClearShrink(msg.data);
+
+    return true;
+}
+
+size_t Sv2Transport::GetSendMemoryUsage() const noexcept
+{
+    AssertLockNotHeld(m_send_mutex);
+    LOCK(m_send_mutex);
+
+    return sizeof(m_send_buffer) + memusage::DynamicUsage(m_send_buffer);
+}
+
+bool Sv2Transport::ReceivedBytes(Span<const uint8_t>& msg_bytes) noexcept
+{
+    AssertLockNotHeld(m_send_mutex);
+    AssertLockNotHeld(m_recv_mutex);
+    /** How many bytes to allocate in the receive buffer at most above what is received so far. */
+    static constexpr size_t MAX_RESERVE_AHEAD = 256 * 1024; // TODO: reduce to NOISE_MAX_CHUNK_SIZE?
+
+    LOCK(m_recv_mutex);
+    // Process the provided bytes in msg_bytes in a loop. In each iteration a nonzero number of
+    // bytes (decided by GetMaxBytesToProcess) are taken from the beginning om msg_bytes, and
+    // appended to m_recv_buffer. Then, depending on the receiver state, one of the
+    // ProcessReceived*Bytes functions is called to process the bytes in that buffer.
+    while (!msg_bytes.empty()) {
+        // Decide how many bytes to copy from msg_bytes to m_recv_buffer.
+        size_t max_read = GetMaxBytesToProcess();
+
+        // Reserve space in the buffer if there is not enough.
+        if (m_recv_buffer.size() + std::min(msg_bytes.size(), max_read) > m_recv_buffer.capacity()) {
+            switch (m_recv_state) {
+            case RecvState::HANDSHAKE_STEP_1:
+                m_recv_buffer.reserve(Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE);
+                break;
+            case RecvState::HANDSHAKE_STEP_2:
+                m_recv_buffer.reserve(Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+                break;
+            case RecvState::APP: {
+                // During states where a packet is being received, as much as is expected but never
+                // more than MAX_RESERVE_AHEAD bytes in addition to what is received so far.
+                // This means attackers that want to cause us to waste allocated memory are limited
+                // to MAX_RESERVE_AHEAD above the largest allowed message contents size, and to
+                // MAX_RESERVE_AHEAD more than they've actually sent us.
+                size_t alloc_add = std::min(max_read, msg_bytes.size() + MAX_RESERVE_AHEAD);
+                m_recv_buffer.reserve(m_recv_buffer.size() + alloc_add);
+                break;
+            }
+            case RecvState::APP_READY:
+                // The buffer is empty in this state.
+                Assume(m_recv_buffer.empty());
+                break;
+            }
+        }
+
+        // Can't read more than provided input.
+        max_read = std::min(msg_bytes.size(), max_read);
+        // Copy data to buffer.
+        m_recv_buffer.insert(m_recv_buffer.end(), UCharCast(msg_bytes.data()), UCharCast(msg_bytes.data() + max_read));
+        msg_bytes = msg_bytes.subspan(max_read);
+
+        // Process data in the buffer.
+        switch (m_recv_state) {
+
+        case RecvState::HANDSHAKE_STEP_1:
+            if (!ProcessReceivedEphemeralKeyBytes()) return false;
+            break;
+
+        case RecvState::HANDSHAKE_STEP_2:
+            if (!ProcessReceivedHandshakeReplyBytes()) return false;
+            break;
+
+        case RecvState::APP:
+            if (!ProcessReceivedPacketBytes()) return false;
+            break;
+
+        case RecvState::APP_READY:
+            return true;
+
+        }
+        // Make sure we have made progress before continuing.
+        Assume(max_read > 0);
+    }
+
+    return true;
+}
+
+bool Sv2Transport::ProcessReceivedEphemeralKeyBytes() noexcept
+{
+    AssertLockHeld(m_recv_mutex);
+    AssertLockNotHeld(m_send_mutex);
+    Assume(m_recv_state == RecvState::HANDSHAKE_STEP_1);
+    Assume(m_recv_buffer.size() <= Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE);
+
+    if (m_recv_buffer.size() == Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE) {
+        // Other side's key has been fully received, and can now be Diffie-Hellman
+        // combined with our key. This is act 1 of the Noise Protocol handshake.
+        // TODO handle failure
+        // TODO: MakeByteSpan instead of MakeWritableByteSpan
+        m_cipher.GetHandshakeState().ReadMsgEphemeralPK(MakeWritableByteSpan(m_recv_buffer));
+        m_recv_buffer.clear();
+        SetReceiveState(RecvState::HANDSHAKE_STEP_2);
+
+        LOCK(m_send_mutex);
+        Assume(m_send_buffer.size() == 0);
+
+        // Send our act 2 handshake
+        SendHandshakeReply();
+    } else {
+        // We still have to receive more key bytes.
+    }
+    return true;
+}
+
+bool Sv2Transport::ProcessReceivedHandshakeReplyBytes() noexcept
+{
+    AssertLockHeld(m_recv_mutex);
+    AssertLockNotHeld(m_send_mutex);
+    Assume(m_recv_state == RecvState::HANDSHAKE_STEP_2);
+    Assume(m_recv_buffer.size() <= Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+
+    if (m_recv_buffer.size() == Sv2HandshakeState::HANDSHAKE_STEP2_SIZE) {
+        // TODO handle failure
+        // TODO: MakeByteSpan instead of MakeWritableByteSpan
+        bool res = m_cipher.GetHandshakeState().ReadMsgES(MakeWritableByteSpan(m_recv_buffer));
+        if (!res) return false;
+        m_recv_buffer.clear();
+        m_cipher.FinishHandshake();
+        SetReceiveState(RecvState::APP);
+
+        LOCK(m_send_mutex);
+        Assume(m_send_buffer.size() == 0);
+
+        SetSendState(SendState::READY);
+    } else {
+        // We still have to receive more key bytes.
+    }
+    return true;
+}
+
+size_t Sv2Transport::GetMaxBytesToProcess() noexcept
+{
+    AssertLockHeld(m_recv_mutex);
+    switch (m_recv_state) {
+    case RecvState::HANDSHAKE_STEP_1:
+        // In this state, we only allow the 64-byte key into the receive buffer.
+        Assume(m_recv_buffer.size() <= Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE);
+        return Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE - m_recv_buffer.size();
+    case RecvState::HANDSHAKE_STEP_2:
+        // In this state, we only allow the handshake reply into the receive buffer.
+        Assume(m_recv_buffer.size() <= Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+        return Sv2HandshakeState::HANDSHAKE_STEP2_SIZE - m_recv_buffer.size();
+    case RecvState::APP:
+        // Decode a packet. Process the header first,
+        // so that we know where the current packet ends (and we don't process bytes from the next
+        // packet yet). Then, process the ciphertext bytes of the current packet.
+        if (m_recv_buffer.size() < SV2_HEADER_ENCRYPTED_SIZE) {
+            return SV2_HEADER_ENCRYPTED_SIZE - m_recv_buffer.size();
+        } else {
+            // When transitioning from receiving the packet length to receiving its ciphertext,
+            // the encrypted header is left in the receive buffer.
+            size_t expanded_size_with_header = SV2_HEADER_ENCRYPTED_SIZE + Sv2Cipher::EncryptedMessageSize(m_header.m_msg_len);
+            return expanded_size_with_header - m_recv_buffer.size();
+        }
+    case RecvState::APP_READY:
+        // No bytes can be processed until GetMessage() is called.
+        return 0;
+    }
+    Assume(false); // unreachable
+    return 0;
+}
+
+bool Sv2Transport::ProcessReceivedPacketBytes() noexcept
+{
+    AssertLockHeld(m_recv_mutex);
+    Assume(m_recv_state == RecvState::APP);
+
+    // The maximum permitted decrypted payload size for a packet
+    static constexpr size_t MAX_CONTENTS_LEN = 16777215; // 24 bit unsigned;
+
+    Assume(m_recv_buffer.size() <= SV2_HEADER_ENCRYPTED_SIZE || m_header.m_msg_len > 0);
+
+    if (m_recv_buffer.size() == SV2_HEADER_ENCRYPTED_SIZE) {
+        // Header received, decrypt it.
+        std::array<std::byte, SV2_HEADER_PLAIN_SIZE> header_plain;
+        if  (!m_cipher.DecryptMessage(MakeWritableByteSpan(m_recv_buffer), header_plain)) {
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Debug, "Failed to decrypt header\n");
+            return false;
+        }
+
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Header: %s\n", HexStr(header_plain));
+
+        // Decode header
+        DataStream ss_header{header_plain};
+        node::Sv2NetHeader header;
+        ss_header >> header;
+        m_header = std::move(header);
+
+        // TODO: 16 MB is pretty large, maybe set lower limits for most or all message types?
+        if (m_header.m_msg_len > MAX_CONTENTS_LEN) {
+            LogTrace(BCLog::SV2, "Packet too large (%u bytes)\n", m_header.m_msg_len);
+            return false;
+        }
+
+        // Disconnect for empty messages (TODO: check the spec)
+        if (m_header.m_msg_len == 0) {
+            LogTrace(BCLog::SV2, "Empty message\n");
+            return false;
+        }
+        LogTrace(BCLog::SV2, "Expecting %d bytes payload (plain)\n", m_header.m_msg_len);
+    } else if (m_recv_buffer.size() > SV2_HEADER_ENCRYPTED_SIZE &&
+               m_recv_buffer.size() == SV2_HEADER_ENCRYPTED_SIZE + Sv2Cipher::EncryptedMessageSize(m_header.m_msg_len)) {
+        /** Ciphertext received: decrypt into decode_buffer and deserialize into m_message.
+          *
+          * Note that it is impossible to reach this branch without hitting the
+          * branch above first, as GetMaxBytesToProcess only allows up to
+          * SV2_HEADER_ENCRYPTED_SIZE into the buffer before that point. */
+        std::vector<std::uint8_t> payload;
+        payload.resize(m_header.m_msg_len);
+
+        Span<std::byte> recv_span{MakeWritableByteSpan(m_recv_buffer).subspan(SV2_HEADER_ENCRYPTED_SIZE)};
+        if (!m_cipher.DecryptMessage(recv_span, MakeWritableByteSpan(payload))) {
+            LogPrintLevel(BCLog::SV2, BCLog::Level::Debug, "Failed to decrypt message payload\n");
+            return false;
+        }
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Payload: %s\n", HexStr(payload));
+
+        // Wipe the receive buffer where the next packet will be received into.
+        ClearShrink(m_recv_buffer);
+
+        Sv2NetMsg message{m_header.m_msg_type, std::move(payload)};
+        m_message = std::move(message);
+
+        // At this point we have a valid message decrypted into m_message.
+        SetReceiveState(RecvState::APP_READY);
+    } else {
+        // We either have less than 22 bytes, so we don't know the packet's length yet, or more
+        // than 22 bytes but less than the packet's full ciphertext. Wait until those arrive.
+        LogTrace(BCLog::SV2, "Waiting for more bytes\n");
+    }
+    return true;
+}
+
+bool Sv2Transport::ReceivedMessageComplete() const noexcept
+{
+    AssertLockNotHeld(m_recv_mutex);
+    LOCK(m_recv_mutex);
+
+    return m_recv_state == RecvState::APP_READY;
+}
+
+CNetMessage Sv2Transport::GetReceivedMessage(std::chrono::microseconds time, bool& reject_message) noexcept
+{
+    AssertLockNotHeld(m_recv_mutex);
+    LOCK(m_recv_mutex);
+    Assume(m_recv_state == RecvState::APP_READY);
+
+    SetReceiveState(RecvState::APP);
+    return m_message; // Sv2NetMsg is wrapped in a CNetMessage
+}
+
+Transport::Info Sv2Transport::GetInfo() const noexcept
+{
+    return {.transport_type = TransportProtocolType::V1, .session_id = {}};
+}
+
+std::string RecvStateAsString(Sv2Transport::RecvState state)
+{
+    switch (state) {
+    case Sv2Transport::RecvState::HANDSHAKE_STEP_1:
+        return "HANDSHAKE_STEP_1";
+    case Sv2Transport::RecvState::HANDSHAKE_STEP_2:
+        return "HANDSHAKE_STEP_2";
+    case Sv2Transport::RecvState::APP:
+        return "APP";
+    case Sv2Transport::RecvState::APP_READY:
+        return "APP_READY";
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
+}
+
+std::string SendStateAsString(Sv2Transport::SendState state)
+{
+    switch (state) {
+    case Sv2Transport::SendState::HANDSHAKE_STEP_1:
+        return "HANDSHAKE_STEP_1";
+    case Sv2Transport::SendState::HANDSHAKE_STEP_2:
+        return "HANDSHAKE_STEP_2";
+    case Sv2Transport::SendState::READY:
+        return "READY";
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
+}

--- a/src/common/sv2_transport.h
+++ b/src/common/sv2_transport.h
@@ -1,0 +1,194 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMMON_SV2_TRANSPORT_H
+#define BITCOIN_COMMON_SV2_TRANSPORT_H
+
+#include <common/sv2_messages.h>
+#include <common/sv2_noise.h>
+#include <net.h> // For Transport, CNetMessage and CSerializedNetMsg
+#include <sync.h>
+
+static constexpr size_t SV2_HEADER_PLAIN_SIZE{6};
+static constexpr size_t SV2_HEADER_ENCRYPTED_SIZE{SV2_HEADER_PLAIN_SIZE + Poly1305::TAGLEN};
+
+using node::Sv2NetHeader;
+using node::Sv2NetMsg;
+
+class Sv2Transport final : public Transport
+{
+public:
+
+    // The sender side and receiver side of Sv2Transport are state machines that are transitioned
+    // through, based on what has been received. The receive state corresponds to the contents of,
+    // and bytes received to, the receive buffer. The send state controls what can be appended to
+    // the send buffer and what can be sent from it.
+
+    /** State type that defines the current contents of the receive buffer and/or how the next
+     *  received bytes added to it will be interpreted.
+     *
+     * Diagram:
+     *
+     *   start(responder)
+     *        |              start(initiator)
+     *        |                     |            /---------\
+     *        |                     |            |         |
+     *        v                     v            v         |
+     *  HANDSHAKE_STEP_1 -> HANDSHAKE_STEP_2 -> APP -> APP_READY
+     */
+    enum class RecvState : uint8_t {
+        /** Handshake Act 1: -> E */
+        HANDSHAKE_STEP_1,
+
+        /** Handshake Act 2: <- e, ee, s, es, SIGNATURE_NOISE_MESSAGE */
+        HANDSHAKE_STEP_2,
+
+        /** Application packet.
+         *
+         * A packet is received, and decrypted/verified. If that succeeds, the
+         * state becomes APP_READY and the decrypted message is kept in m_message
+         * until it is retrieved by GetMessage(). */
+        APP,
+
+        /** Nothing (an application packet is available for GetMessage()).
+         *
+         * Nothing can be received in this state. When the message is retrieved
+         * by GetMessage(), the state becomes APP again. */
+        APP_READY,
+    };
+
+    /** State type that controls the sender side.
+     *
+     * Diagram:
+     *
+     *   start(initiator)
+     *        |             start(responder)
+     *        |                  |
+     *        |                  |
+     *        v                  v
+     *  HANDSHAKE_STEP_1 -> HANDSHAKE_STEP_2 -> READY
+     */
+    enum class SendState : uint8_t {
+        /** Handshake Act 1: -> E */
+        HANDSHAKE_STEP_1,
+
+        /** Handshake Act 2: <- e, ee, s, es, SIGNATURE_NOISE_MESSAGE */
+        HANDSHAKE_STEP_2,
+
+        /** Normal sending state.
+         *
+         * In this state, the ciphers are initialized, so packets can be sent.
+         * In this state a message can be provided if the send buffer is empty. */
+        READY,
+    };
+
+private:
+
+    /** Cipher state. */
+    Sv2Cipher m_cipher;
+
+    /** Whether we are the initiator side. */
+    const bool m_initiating;
+
+    /** Lock for receiver-side fields. */
+    mutable Mutex m_recv_mutex ACQUIRED_BEFORE(m_send_mutex);
+    /** Receive buffer; meaning is determined by m_recv_state. */
+    std::vector<uint8_t> m_recv_buffer GUARDED_BY(m_recv_mutex);
+    /** AAD expected in next received packet (currently used only for garbage). */
+    std::vector<uint8_t> m_recv_aad GUARDED_BY(m_recv_mutex);
+    /** Current receiver state. */
+    RecvState m_recv_state GUARDED_BY(m_recv_mutex);
+
+    /** Lock for sending-side fields. If both sending and receiving fields are accessed,
+     *  m_recv_mutex must be acquired before m_send_mutex. */
+    mutable Mutex m_send_mutex ACQUIRED_AFTER(m_recv_mutex);
+    /** The send buffer; meaning is determined by m_send_state. */
+    std::vector<uint8_t> m_send_buffer GUARDED_BY(m_send_mutex);
+    /** How many bytes from the send buffer have been sent so far. */
+    uint32_t m_send_pos GUARDED_BY(m_send_mutex) {0};
+    /** The garbage sent, or to be sent (MAYBE_V1 and AWAITING_KEY state only). */
+    std::vector<uint8_t> m_send_garbage GUARDED_BY(m_send_mutex);
+    /** Type of the message being sent. */
+    std::string m_send_type GUARDED_BY(m_send_mutex);
+    /** Current sender state. */
+    SendState m_send_state GUARDED_BY(m_send_mutex);
+
+    /** Change the receive state. */
+    void SetReceiveState(RecvState recv_state) noexcept EXCLUSIVE_LOCKS_REQUIRED(m_recv_mutex);
+    /** Change the send state. */
+    void SetSendState(SendState send_state) noexcept EXCLUSIVE_LOCKS_REQUIRED(m_send_mutex);
+    /** Given a packet's contents, find the message type (if valid), and strip it from contents. */
+    static std::optional<std::string> GetMessageType(Span<const uint8_t>& contents) noexcept;
+    /** Determine how many received bytes can be processed in one go (not allowed in V1 state). */
+    size_t GetMaxBytesToProcess() noexcept EXCLUSIVE_LOCKS_REQUIRED(m_recv_mutex);
+    /** Put our ephemeral public key in the send buffer. */
+    void StartSendingHandshake() noexcept EXCLUSIVE_LOCKS_REQUIRED(m_send_mutex, !m_recv_mutex);
+    /** Put second part of the handshake in the send buffer. */
+    void SendHandshakeReply() noexcept EXCLUSIVE_LOCKS_REQUIRED(m_send_mutex, m_recv_mutex);
+    /** Process bytes in m_recv_buffer, while in HANDSHAKE_STEP_1 state. */
+    bool ProcessReceivedEphemeralKeyBytes() noexcept EXCLUSIVE_LOCKS_REQUIRED(m_recv_mutex, !m_send_mutex);
+    /** Process bytes in m_recv_buffer, while in HANDSHAKE_STEP_2 state. */
+    bool ProcessReceivedHandshakeReplyBytes() noexcept EXCLUSIVE_LOCKS_REQUIRED(m_recv_mutex, !m_send_mutex);
+
+    /** Process bytes in m_recv_buffer, while in VERSION/APP state. */
+    bool ProcessReceivedPacketBytes() noexcept EXCLUSIVE_LOCKS_REQUIRED(m_recv_mutex);
+
+    /** In APP, the decrypted header, if m_recv_buffer.size() >=
+    *  SV2_HEADER_ENCRYPTED_SIZE. Unspecified otherwise. */
+    Sv2NetHeader m_header GUARDED_BY(m_recv_mutex);
+    /* In APP_READY the last retrieved message. Unspecified otherwise */
+    Sv2NetMsg m_message GUARDED_BY(m_recv_mutex);
+
+public:
+    /** Construct a Stratum v2 transport as the initiator
+      *
+      * @param[in] static_key a securely generated key
+
+      */
+    Sv2Transport(CKey static_key, XOnlyPubKey responder_authority_key) noexcept;
+
+        /** Construct a Stratum v2 transport as the responder
+      *
+      * @param[in] static_key a securely generated key
+
+      */
+    Sv2Transport(CKey static_key, Sv2SignatureNoiseMessage certificate) noexcept;
+
+    // Receive side functions.
+    bool ReceivedMessageComplete() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex);
+    bool ReceivedBytes(Span<const uint8_t>& msg_bytes) noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex, !m_send_mutex);
+
+    CNetMessage GetReceivedMessage(std::chrono::microseconds time, bool& reject_message) noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex);
+
+    // Send side functions.
+    bool SetMessageToSend(CSerializedNetMsg& msg) noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
+
+    BytesToSend GetBytesToSend(bool have_next_message) const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
+
+    void MarkBytesSent(size_t bytes_sent) noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
+    size_t GetSendMemoryUsage() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
+
+    // Miscellaneous functions.
+    bool ShouldReconnectV1() const noexcept override { return false; };
+    Info GetInfo() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex);
+
+    // Test only
+    uint256 NoiseHash() const { return m_cipher.GetHash(); };
+    RecvState GetRecvState() EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex) {
+        AssertLockNotHeld(m_recv_mutex);
+        LOCK(m_recv_mutex);
+        return  m_recv_state;
+    };
+    SendState GetSendState() EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex) {
+        AssertLockNotHeld(m_send_mutex);
+        LOCK(m_send_mutex);
+        return  m_send_state;
+    };
+};
+
+/** Convert TransportProtocolType enum to a string value */
+std::string RecvStateAsString(Sv2Transport::RecvState state);
+std::string SendStateAsString(Sv2Transport::SendState state);
+
+#endif // BITCOIN_COMMON_SV2_TRANSPORT_H

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <deque>
+
 #include <consensus/merkle.h>
 #include <hash.h>
 
@@ -83,3 +85,55 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block, bool* mutated)
     return ComputeMerkleRoot(std::move(leaves), mutated);
 }
 
+static uint256 HashTwoTxIDs(const uint256& txid1, const uint256& txid2) {
+    HashWriter hasher{};
+    hasher << txid1 << txid2;
+    return hasher.GetHash();
+}
+
+std::vector<uint256> GetCoinBaseMerklePath(const CBlock& block)
+{
+    auto size = block.vtx.size();
+    // If we have only the coinbase tx, we don't have a merkle path
+    if (size == 1) {
+        return {};
+    // If we have coinbase tx and another tx the path is the second node id
+    } else if (size == 2) {
+        std::vector<uint256> path;
+        path.push_back(block.vtx[1]->GetHash());
+        return path;
+    // Otherwise we calculate the merkle path
+    } else {
+        std::deque<uint256> id_list;
+        for (const auto& tx : block.vtx) {
+            id_list.push_back(tx->GetHash());
+        }
+        // Last id must be duplicated when txs are odds
+        if (size % 2 == 1) {
+            id_list.push_back(block.vtx[size - 1]->GetHash());
+        }
+
+        // Remove coinbase
+        id_list.pop_front();
+
+        std::vector<uint256> path;
+
+        // First path element is always the second tx
+        path.push_back(id_list.front());
+        id_list.pop_front();
+
+        while (!id_list.empty()) {
+            for (size_t i = 0; i < id_list.size() / 2; ++i) {
+                id_list[i] = HashTwoTxIDs(id_list[i * 2], id_list[i * 2 + 1]);
+            }
+            id_list.resize(id_list.size()/2);
+            path.push_back(id_list.front());
+            id_list.pop_front();
+            if (id_list.size() % 2 == 1) {
+                id_list.push_back(id_list[id_list.size() - 1]);
+            }
+        }
+
+        return path;
+    }
+}

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -24,4 +24,9 @@ uint256 BlockMerkleRoot(const CBlock& block, bool* mutated = nullptr);
  */
 uint256 BlockWitnessMerkleRoot(const CBlock& block, bool* mutated = nullptr);
 
+/*
+ * Merkle path hashes ordered from deepest.
+ */
+std::vector<uint256> GetCoinBaseMerklePath(const CBlock& block);
+
 #endif // BITCOIN_CONSENSUS_MERKLE_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -457,10 +457,12 @@ void SetupServerArgs(ArgsManager& argsman)
 
     const auto defaultBaseParams = CreateBaseChainParams(ChainType::MAIN);
     const auto testnetBaseParams = CreateBaseChainParams(ChainType::TESTNET);
+    const auto testnet4BaseParams = CreateBaseChainParams(ChainType::TESTNET4);
     const auto signetBaseParams = CreateBaseChainParams(ChainType::SIGNET);
     const auto regtestBaseParams = CreateBaseChainParams(ChainType::REGTEST);
     const auto defaultChainParams = CreateChainParams(argsman, ChainType::MAIN);
     const auto testnetChainParams = CreateChainParams(argsman, ChainType::TESTNET);
+    const auto testnet4ChainParams = CreateChainParams(argsman, ChainType::TESTNET4);
     const auto signetChainParams = CreateChainParams(argsman, ChainType::SIGNET);
     const auto regtestChainParams = CreateChainParams(argsman, ChainType::REGTEST);
 
@@ -474,7 +476,7 @@ void SetupServerArgs(ArgsManager& argsman)
 #if HAVE_SYSTEM
     argsman.AddArg("-alertnotify=<cmd>", "Execute command when an alert is raised (%s in cmd is replaced by message)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif
-    argsman.AddArg("-assumevalid=<hex>", strprintf("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s, signet: %s)", defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex(), signetChainParams->GetConsensus().defaultAssumeValid.GetHex()), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-assumevalid=<hex>", strprintf("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet3: %s, testnet4: %s, signet: %s)", defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnet4ChainParams->GetConsensus().defaultAssumeValid.GetHex(), signetChainParams->GetConsensus().defaultAssumeValid.GetHex()), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blocksdir=<dir>", "Specify directory to hold blocks subdirectory for *.dat files (default: <datadir>)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-fastprune", "Use smaller block files and lower minimum prune height for testing purposes", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
 #if HAVE_SYSTEM
@@ -493,7 +495,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-maxmempool=<n>", strprintf("Keep the transaction memory pool below <n> megabytes (default: %u)", DEFAULT_MAX_MEMPOOL_SIZE_MB), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-maxorphantx=<n>", strprintf("Keep at most <n> unconnectable transactions in memory (default: %u)", DEFAULT_MAX_ORPHAN_TRANSACTIONS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-mempoolexpiry=<n>", strprintf("Do not keep transactions in the mempool longer than <n> hours (default: %u)", DEFAULT_MEMPOOL_EXPIRY_HOURS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet: %s, signet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex(), signetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet3: %s, testnet4: %s, signet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnet4ChainParams->GetConsensus().nMinimumChainWork.GetHex(), signetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (0 = auto, up to %d, <0 = leave that many cores free, default: %d)",
         MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempool", strprintf("Whether to save the mempool on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_MEMPOOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -522,7 +524,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-addnode=<ip>", strprintf("Add a node to connect to and attempt to keep the connection open (see the addnode RPC help for more info). This option can be specified multiple times to add multiple nodes; connections are limited to %u at a time and are counted separately from the -maxconnections limit.", MAX_ADDNODE_CONNECTIONS), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-asmap=<file>", strprintf("Specify asn mapping used for bucketing of the peers (default: %s). Relative paths will be prefixed by the net-specific datadir location.", DEFAULT_ASMAP_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-bantime=<n>", strprintf("Default duration (in seconds) of manually configured bans (default: %u)", DEFAULT_MISBEHAVING_BANTIME), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
-    argsman.AddArg("-bind=<addr>[:<port>][=onion]", strprintf("Bind to given address and always listen on it (default: 0.0.0.0). Use [host]:port notation for IPv6. Append =onion to tag any incoming connections to that address and port as incoming Tor connections (default: 127.0.0.1:%u=onion, testnet: 127.0.0.1:%u=onion, signet: 127.0.0.1:%u=onion, regtest: 127.0.0.1:%u=onion)", defaultBaseParams->OnionServiceTargetPort(), testnetBaseParams->OnionServiceTargetPort(), signetBaseParams->OnionServiceTargetPort(), regtestBaseParams->OnionServiceTargetPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-bind=<addr>[:<port>][=onion]", strprintf("Bind to given address and always listen on it (default: 0.0.0.0). Use [host]:port notation for IPv6. Append =onion to tag any incoming connections to that address and port as incoming Tor connections (default: 127.0.0.1:%u=onion, testnet3: 127.0.0.1:%u=onion, testnet4: 127.0.0.1:%u=onion, signet: 127.0.0.1:%u=onion, regtest: 127.0.0.1:%u=onion)", defaultBaseParams->OnionServiceTargetPort(), testnetBaseParams->OnionServiceTargetPort(), testnet4BaseParams->OnionServiceTargetPort(), signetBaseParams->OnionServiceTargetPort(), regtestBaseParams->OnionServiceTargetPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-cjdnsreachable", "If set, then this host is configured for CJDNS (connecting to fc00::/8 addresses would lead us to the CJDNS network, see doc/cjdns.md) (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-connect=<ip>", "Connect only to the specified node; -noconnect disables automatic connections (the rules for this peer are the same as for -addnode). This option can be specified multiple times to connect to multiple nodes.", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-discover", "Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
@@ -549,7 +551,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-peerbloomfilters", strprintf("Support filtering of blocks and transaction with bloom filters (default: %u)", DEFAULT_PEERBLOOMFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerblockfilters", strprintf("Serve compact block filters to peers per BIP 157 (default: %u)", DEFAULT_PEERBLOCKFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-txreconciliation", strprintf("Enable transaction reconciliations per BIP 330 (default: %d)", DEFAULT_TXRECONCILIATION_ENABLE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
-    argsman.AddArg("-port=<port>", strprintf("Listen for connections on <port> (default: %u, testnet: %u, signet: %u, regtest: %u). Not relevant for I2P (see doc/i2p.md).", defaultChainParams->GetDefaultPort(), testnetChainParams->GetDefaultPort(), signetChainParams->GetDefaultPort(), regtestChainParams->GetDefaultPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-port=<port>", strprintf("Listen for connections on <port> (default: %u, testnet3: %u, testnet4: %u, signet: %u, regtest: %u). Not relevant for I2P (see doc/i2p.md).", defaultChainParams->GetDefaultPort(), testnetChainParams->GetDefaultPort(), testnet4ChainParams->GetDefaultPort(), signetChainParams->GetDefaultPort(), regtestChainParams->GetDefaultPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
 #ifdef HAVE_SOCKADDR_UN
     argsman.AddArg("-proxy=<ip:port|path>", "Connect through SOCKS5 proxy, set -noproxy to disable (default: disabled). May be a local file path prefixed with 'unix:' if the proxy supports it.", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_ELISION, OptionsCategory::CONNECTION);
 #else
@@ -669,7 +671,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-rpccookiefile=<loc>", "Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpccookieperms=<readable-by>", strprintf("Set permissions on the RPC auth cookie file so that it is readable by [owner|group|all] (default: owner [via umask 0077])"), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcpassword=<pw>", "Password for JSON-RPC connections", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::RPC);
-    argsman.AddArg("-rpcport=<port>", strprintf("Listen for JSON-RPC connections on <port> (default: %u, testnet: %u, signet: %u, regtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), signetBaseParams->RPCPort(), regtestBaseParams->RPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    argsman.AddArg("-rpcport=<port>", strprintf("Listen for JSON-RPC connections on <port> (default: %u, testnet3: %u, testnet4: %u, signet: %u, regtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), testnet4BaseParams->RPCPort(), signetBaseParams->RPCPort(), regtestBaseParams->RPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-rpcthreads=<n>", strprintf("Set the number of threads to service RPC calls (default: %d)", DEFAULT_HTTP_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::RPC);
@@ -916,6 +918,11 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     if (!errors.empty()) {
         return InitError(errors);
+    }
+
+    // Testnet3 deprecation warning
+    if (chain == ChainType::TESTNET) {
+        LogPrintf("Warning: Support for testnet3 is deprecated and will be removed in an upcoming release. Consider switching to testnet4.\n");
     }
 
     // Warn if unrecognized section name are present in the config file.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -659,7 +659,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-blockmaxweight=<n>", strprintf("Set maximum BIP141 block weight (default: %d)", DEFAULT_BLOCK_MAX_WEIGHT), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-blockmintxfee=<amt>", strprintf("Set lowest fee rate (in %s/kvB) for transactions to be included in block creation. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_BLOCK_MIN_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-blockversion=<n>", "Override block version to test forking scenarios", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::BLOCK_CREATION);
-    argsman.AddArg("-sv2", "Bitcoind will act as a Stratum v2 Template Provider (default: false)", ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    argsman.AddArg("-sv2", "Bitcoind will act as a Stratum v2 Template Provider, see doc/stratum-v2.md (default: false)", ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-sv2interval", strprintf("Template Provider block template update interval (default: %d seconds)", Sv2TemplateProviderOptions().fee_check_interval.count()), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-sv2feedelta", strprintf("Minimum fee delta for Template Provider to send update upstream (default: %d sat)", uint64_t(Sv2TemplateProviderOptions().fee_delta)), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -53,7 +53,7 @@
 #include <node/mempool_persist_args.h>
 #include <node/miner.h>
 #include <node/peerman_args.h>
-#include <policy/feerate.h>
+#include <node/sv2_template_provider.h>
 #include <policy/fees.h>
 #include <policy/fees_args.h>
 #include <policy/policy.h>
@@ -257,6 +257,9 @@ void Interrupt(NodeContext& node)
     InterruptRPC();
     InterruptREST();
     InterruptTorControl();
+    if (node.sv2_template_provider) {
+        node.sv2_template_provider->Interrupt();
+    }
     InterruptMapPort();
     if (node.connman)
         node.connman->Interrupt();
@@ -296,6 +299,9 @@ void Shutdown(NodeContext& node)
 
     StopTorControl();
 
+    // Stop Template Provider
+    if (node.sv2_template_provider) node.sv2_template_provider->StopThreads();
+
     if (node.chainman && node.chainman->m_thread_load.joinable()) node.chainman->m_thread_load.join();
     // After everything has been shut down, but before things get flushed, stop the
     // the scheduler. After this point, SyncWithValidationInterfaceQueue() should not be called anymore
@@ -309,6 +315,7 @@ void Shutdown(NodeContext& node)
     node.banman.reset();
     node.addrman.reset();
     node.netgroupman.reset();
+    node.sv2_template_provider.reset();
 
     if (node.mempool && node.mempool->GetLoadTried() && ShouldPersistMempool(*node.args)) {
         DumpMempool(*node.mempool, MempoolPath(*node.args));
@@ -650,6 +657,9 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-blockmaxweight=<n>", strprintf("Set maximum BIP141 block weight (default: %d)", DEFAULT_BLOCK_MAX_WEIGHT), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-blockmintxfee=<amt>", strprintf("Set lowest fee rate (in %s/kvB) for transactions to be included in block creation. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_BLOCK_MIN_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-blockversion=<n>", "Override block version to test forking scenarios", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::BLOCK_CREATION);
+    argsman.AddArg("-sv2", "Bitcoind will act as a Stratum v2 Template Provider (default: false)", ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    argsman.AddArg("-sv2interval", strprintf("Template Provider block template update interval (default: %d seconds)", Sv2TemplateProviderOptions().fee_check_interval.count()), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    argsman.AddArg("-sv2feedelta", strprintf("Minimum fee delta for Template Provider to send update upstream (default: %d sat)", uint64_t(Sv2TemplateProviderOptions().fee_delta)), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
 
     argsman.AddArg("-rest", strprintf("Accept public REST requests (default: %u)", DEFAULT_REST_ENABLE), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcallowip=<ip>", "Allow JSON-RPC connections from specified source. Valid values for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0), a network/CIDR (e.g. 1.2.3.4/24), all ipv4 (0.0.0.0/0), or all ipv6 (::/0). This option can be specified multiple times", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
@@ -667,6 +677,8 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-rpcwhitelistdefault", "Sets default behavior for rpc whitelisting. Unless rpcwhitelistdefault is set to 0, if any -rpcwhitelist is set, the rpc server acts as if all rpc users are subject to empty-unless-otherwise-specified whitelists. If rpcwhitelistdefault is set to 1 and no -rpcwhitelist is set, rpc server acts as if all rpc users are subject to empty whitelists.", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    argsman.AddArg("-sv2bind=<addr>[:<port>]", strprintf("Bind to given address and always listen on it (default: 127.0.0.1). Use [host]:port notation for IPv6."), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-sv2port=<port>", strprintf("Listen for Stratum v2 connections on <port> (default: %u, testnet: %u, signet: %u, regtest: %u)", defaultBaseParams->Sv2Port(), testnetBaseParams->Sv2Port(), signetBaseParams->Sv2Port(), regtestBaseParams->Sv2Port()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
 
 #if HAVE_DECL_FORK
     argsman.AddArg("-daemon", strprintf("Run in the background as a daemon and accept commands (default: %d)", DEFAULT_DAEMON), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -1307,6 +1319,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         {"-onion",                  true},
         {"-proxy",                  true},
         {"-rpcbind",                false},
+        {"-sv2bind",                false},
         {"-torcontrol",             false},
         {"-whitebind",              false},
         {"-zmqpubhashblock",        true},
@@ -1954,6 +1967,47 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     if (!node.connman->Start(scheduler, connOptions)) {
         return false;
+    }
+
+    if (args.GetBoolArg("-sv2", false)) {
+        assert(!node.sv2_template_provider);
+        assert(node.mining);
+
+        Sv2TemplateProviderOptions options{};
+
+        node.sv2_template_provider = std::make_unique<Sv2TemplateProvider>(*node.mining);
+
+        const std::string sv2_port_arg = args.GetArg("-sv2port", "");
+
+        if (sv2_port_arg.empty()) {
+            options.port = BaseParams().Sv2Port();
+        } else {
+            if (!ParseUInt16(sv2_port_arg, &options.port) || options.port == 0) {
+                return InitError(InvalidPortErrMsg("sv2port", sv2_port_arg));
+            }
+        }
+
+        if (gArgs.IsArgSet("-sv2bind")) { // Specific bind address
+            std::optional<std::string> sv2_bind{gArgs.GetArg("-sv2bind")};
+            if (sv2_bind) {
+                if (!SplitHostPort(sv2_bind.value(), options.port, options.host)) {
+                    throw std::runtime_error(strprintf("Invalid port %d", options.port));
+                }
+            }
+        }
+
+        options.fee_delta = gArgs.GetIntArg("-sv2feedelta", Sv2TemplateProviderOptions().fee_delta);
+
+        if (gArgs.IsArgSet("-sv2interval")) {
+            if (args.GetIntArg("-sv2interval", 0) < 1) {
+                return InitError(Untranslated("-sv2interval must be at least one second"));
+            }
+            options.fee_check_interval = std::chrono::seconds(gArgs.GetIntArg("-sv2interval", 0));
+        }
+
+        if (!node.sv2_template_provider->Start(options)) {
+            return InitError(_("Unable to start Stratum v2 Template Provider"));
+        }
     }
 
     // ********************************************************* Step 13: finished

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_INTERFACES_MINING_H
 #define BITCOIN_INTERFACES_MINING_H
 
+#include <consensus/amount.h>
+#include <primitives/transaction.h>
 #include <node/types.h>
 #include <uint256.h>
 
@@ -12,19 +14,35 @@
 #include <optional>
 
 namespace node {
-struct CBlockTemplate;
 struct NodeContext;
 } // namespace node
 
 class BlockValidationState;
 class CBlock;
+class CBlockHeader;
 class CScript;
 
 namespace interfaces {
 
+//! Block template interface
+class BlockTemplate
+{
+public:
+    virtual ~BlockTemplate() = default;
+
+    virtual CBlockHeader getBlockHeader() = 0;
+    virtual CBlock getBlock() = 0;
+
+    virtual std::vector<CAmount> getTxFees() = 0;
+    virtual std::vector<int64_t> getTxSigops() = 0;
+
+    virtual CTransactionRef getCoinbaseTx() = 0;
+    virtual std::vector<unsigned char> getCoinbaseCommitment() = 0;
+    virtual int getWitnessCommitmentIndex() = 0;
+};
+
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)
 //! ability to create block templates.
-
 class Mining
 {
 public:
@@ -46,7 +64,7 @@ public:
      * @param[in] options options for creating the block
      * @returns a block template
      */
-    virtual std::unique_ptr<node::CBlockTemplate> createNewBlock(const CScript& script_pub_key, const node::BlockCreateOptions& options={}) = 0;
+    virtual std::unique_ptr<BlockTemplate> createNewBlock(const CScript& script_pub_key, const node::BlockCreateOptions& options={}) = 0;
 
     /**
      * Processes new block. A valid new block is automatically relayed to peers.

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -39,6 +39,7 @@ public:
     virtual CTransactionRef getCoinbaseTx() = 0;
     virtual std::vector<unsigned char> getCoinbaseCommitment() = 0;
     virtual int getWitnessCommitmentIndex() = 0;
+    virtual std::vector<uint256> getCoinbaseMerklePath() = 0;
 };
 
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -75,6 +75,19 @@ public:
      */
     virtual std::pair<uint256, int> waitTipChanged(MillisecondsDouble timeout = MillisecondsDouble::max()) = 0;
 
+    /**
+     * Waits for fees in the next block to rise, a new tip or the timeout.
+     *
+     * @param[in] timeout how long to wait for a fee increase
+     * @param[in] tip block hash that the most recent template builds on
+     * @param[in] fee_delta currently ignored: how much total fees in the next block should rise.
+     * @param[in,out] fees_before currently ignored: fees for the most recent template
+     * @param[out] tip_changed whether a new tip arrived during the wait
+     *
+     * @returns true if fees increased, false if a new tip arrives or the timeout occurs
+     */
+    virtual bool waitFeesChanged(MillisecondsDouble timeout, uint256 tip, CAmount fee_delta, CAmount& fees_before, bool& tip_changed) = 0;
+
    /**
      * Construct a new block template
      *

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -40,6 +40,13 @@ public:
     virtual std::vector<unsigned char> getCoinbaseCommitment() = 0;
     virtual int getWitnessCommitmentIndex() = 0;
     virtual std::vector<uint256> getCoinbaseMerklePath() = 0;
+
+    /**
+     * Construct and broadcast the block.
+     *
+     * @returns if the block was processed, independent of block validity
+     */
+    virtual bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CMutableTransaction coinbase) = 0;
 };
 
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -9,6 +9,7 @@
 #include <primitives/transaction.h>
 #include <node/types.h>
 #include <uint256.h>
+#include <util/time.h>
 
 #include <memory>
 #include <optional>
@@ -64,6 +65,15 @@ public:
 
     //! Returns the hash for the tip of this chain
     virtual std::optional<uint256> getTipHash() = 0;
+
+    /**
+     * Waits for the tip to change
+     *
+     * @param[in] timeout how long to wait for a new tip
+     * @returns hash and height for the new tip or the previous tip if
+     *          interrupted or after the timeout
+     */
+    virtual std::pair<uint256, int> waitTipChanged(MillisecondsDouble timeout = MillisecondsDouble::max()) = 0;
 
    /**
      * Construct a new block template

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -47,7 +47,7 @@ public:
      *
      * @returns if the block was processed, independent of block validity
      */
-    virtual bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CMutableTransaction coinbase) = 0;
+    virtual bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CMutableTransaction coinbase, uint256& new_block_hash) = 0;
 };
 
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)
@@ -94,6 +94,10 @@ public:
      * @param[in] script_pub_key the coinbase output
      * @param[in] options options for creating the block
      * @returns a block template
+     *
+     * TODO: add params for:
+     * 1. refering to a previous template, to a block on top of that
+     * 2. to build an empty block (on top of the previous template)
      */
     virtual std::unique_ptr<BlockTemplate> createNewBlock(const CScript& script_pub_key, const node::BlockCreateOptions& options={}) = 0;
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -287,6 +287,103 @@ public:
 };
 
 /**
+ * Testnet (v4): public test network which is reset from time to time.
+ */
+class CTestNet4Params : public CChainParams {
+public:
+    CTestNet4Params() {
+        m_chain_type = ChainType::TESTNET4;
+        consensus.signet_blocks = false;
+        consensus.signet_challenge.clear();
+        consensus.nSubsidyHalvingInterval = 210000;
+        consensus.BIP34Height = 1;
+        consensus.BIP34Hash = uint256{};
+        consensus.BIP65Height = 1;
+        consensus.BIP66Height = 1;
+        consensus.CSVHeight = 1;
+        consensus.SegwitHeight = 1;
+        consensus.MinBIP9WarningHeight = 0;
+        consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
+        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.fPowAllowMinDifficultyBlocks = true;
+        consensus.fPowNoRetargeting = false;
+        consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
+        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
+
+        // Deployment of Taproot (BIPs 340-342)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
+
+        consensus.nMinimumChainWork = uint256{};
+        consensus.defaultAssumeValid = uint256{};
+
+        pchMessageStart[0] = 0x1c;
+        pchMessageStart[1] = 0x16;
+        pchMessageStart[2] = 0x3f;
+        pchMessageStart[3] = 0x28;
+        nDefaultPort = 48333;
+        nPruneAfterHeight = 1000;
+        m_assumed_blockchain_size = 0;
+        m_assumed_chain_state_size = 0;
+
+        const char* testnet4_genesis_msg = "03/May/2024 000000000000000000001ebd58c244970b3aa9d783bb001011fbe8ea8e98e00e";
+        const CScript testnet4_genesis_script = CScript() << ParseHex("000000000000000000000000000000000000000000000000000000000000000000") << OP_CHECKSIG;
+        genesis = CreateGenesisBlock(testnet4_genesis_msg,
+                testnet4_genesis_script,
+                1714777860,
+                393743547,
+                0x1d00ffff,
+                1,
+                50 * COIN);
+        consensus.hashGenesisBlock = genesis.GetHash();
+        assert(consensus.hashGenesisBlock == uint256S("0x00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043"));
+        assert(genesis.hashMerkleRoot == uint256S("0x7aa0a7ae1e223414cb807e40cd57e667b718e42aaf9306db9102fe28912b7b4e"));
+
+        vFixedSeeds.clear();
+        vSeeds.clear();
+        // nodes with support for servicebits filtering should be at the top
+        vSeeds.emplace_back("seed.testnet4.bitcoin.sprovoost.nl."); // Sjors Provoost
+        vSeeds.emplace_back("seed.testnet4.wiz.biz."); // Jason Maurice
+
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
+        base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
+        base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
+
+        bech32_hrp = "tb";
+
+        vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_test), std::end(chainparams_seed_test));
+
+        fDefaultConsistencyChecks = false;
+        m_is_mockable_chain = false;
+
+        checkpointData = {
+            {
+                {},
+            }
+        };
+
+        m_assumeutxo_data = {
+            {}
+        };
+
+        chainTxData = ChainTxData{
+            .nTime    = 0,
+            .nTxCount = 0,
+            .dTxRate  = 0,
+        };
+    }
+};
+
+/**
  * Signet: test network with an additional consensus parameter (see BIP325).
  */
 class SigNetParams : public CChainParams {
@@ -551,6 +648,11 @@ std::unique_ptr<const CChainParams> CChainParams::Main()
 std::unique_ptr<const CChainParams> CChainParams::TestNet()
 {
     return std::make_unique<const CTestNetParams>();
+}
+
+std::unique_ptr<const CChainParams> CChainParams::TestNet4()
+{
+    return std::make_unique<const CTestNet4Params>();
 }
 
 std::vector<int> CChainParams::GetAvailableSnapshotHeights() const

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -161,6 +161,7 @@ public:
     static std::unique_ptr<const CChainParams> SigNet(const SigNetOptions& options);
     static std::unique_ptr<const CChainParams> Main();
     static std::unique_ptr<const CChainParams> TestNet();
+    static std::unique_ptr<const CChainParams> TestNet4();
 
 protected:
     CChainParams() = default;

--- a/src/key.h
+++ b/src/key.h
@@ -202,6 +202,31 @@ public:
     ECDHSecret ComputeBIP324ECDHSecret(const EllSwiftPubKey& their_ellswift,
                                        const EllSwiftPubKey& our_ellswift,
                                        bool initiating) const;
+
+    /** Straight-forward serialization of key bytes (and compressed flag).
+     *  Use GetPrivKey() for OpenSSL compatible DER encoding.
+     */
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        if (!IsValid()) {
+            throw std::ios_base::failure("invalid key");
+        }
+        s << fCompressed;
+        ::Serialize(s, Span{*this});
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        s >> fCompressed;
+        MakeKeyData();
+        s >> Span{*keydata};
+        if (!Check(keydata->data())) {
+            ClearKeyData();
+            throw std::ios_base::failure("invalid key");
+        }
+    }
 };
 
 CKey GenerateRandomKey(bool compressed = true) noexcept;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -178,6 +178,7 @@ static const std::map<std::string, BCLog::LogFlags> LOG_CATEGORIES_BY_STR{
     {"blockstorage", BCLog::BLOCKSTORAGE},
     {"txreconciliation", BCLog::TXRECONCILIATION},
     {"scan", BCLog::SCAN},
+    {"sv2", BCLog::SV2},
     {"txpackages", BCLog::TXPACKAGES},
     {"1", BCLog::ALL},
     {"all", BCLog::ALL},

--- a/src/logging.h
+++ b/src/logging.h
@@ -69,6 +69,7 @@ namespace BCLog {
         TXRECONCILIATION = (1 << 26),
         SCAN        = (1 << 27),
         TXPACKAGES  = (1 << 28),
+        SV2         = (1 << 30),
         ALL         = ~(uint32_t)0,
     };
     enum class Level {

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -14,6 +14,7 @@
 #include <net_processing.h>
 #include <netgroup.h>
 #include <node/kernel_notifications.h>
+#include <node/sv2_template_provider.h>
 #include <node/warnings.h>
 #include <policy/fees.h>
 #include <scheduler.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -24,6 +24,7 @@ class ChainstateManager;
 class ECC_Context;
 class NetGroupManager;
 class PeerManager;
+class Sv2TemplateProvider;
 namespace interfaces {
 class Chain;
 class ChainClient;
@@ -68,6 +69,7 @@ struct NodeContext {
     std::unique_ptr<PeerManager> peerman;
     std::unique_ptr<ChainstateManager> chainman;
     std::unique_ptr<BanMan> banman;
+    std::unique_ptr<Sv2TemplateProvider> sv2_template_provider;
     ArgsManager* args{nullptr}; // Currently a raw pointer because the memory is not managed by this struct
     std::vector<BaseIndex*> indexes; // raw pointers because memory is not managed by this struct
     std::unique_ptr<interfaces::Chain> chain;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -67,6 +67,7 @@
 
 #include <boost/signals2/signal.hpp>
 
+using interfaces::BlockTemplate;
 using interfaces::BlockTip;
 using interfaces::Chain;
 using interfaces::FoundBlock;
@@ -838,6 +839,49 @@ public:
     NodeContext& m_node;
 };
 
+class BlockTemplateImpl : public BlockTemplate
+{
+public:
+    explicit BlockTemplateImpl(std::unique_ptr<CBlockTemplate> block_template) : m_block_template(std::move(block_template)) {}
+
+    CBlockHeader getBlockHeader() override
+    {
+        return Assert(m_block_template)->block;
+    }
+
+    CBlock getBlock() override
+    {
+        return m_block_template->block;
+    }
+
+    std::vector<CAmount> getTxFees() override
+    {
+        return m_block_template->vTxFees;
+    }
+
+    std::vector<int64_t> getTxSigops() override
+    {
+        return m_block_template->vTxSigOpsCost;
+    }
+
+    CTransactionRef getCoinbaseTx() override
+    {
+        return m_block_template->block.vtx[0];
+    }
+
+    std::vector<unsigned char> getCoinbaseCommitment() override
+    {
+        return m_block_template->vchCoinbaseCommitment;
+    }
+
+    int getWitnessCommitmentIndex() override
+    {
+        return GetWitnessCommitmentIndex(m_block_template->block);
+    }
+
+    std::unique_ptr<CBlockTemplate> m_block_template;
+};
+
 class MinerImpl : public Mining
 {
 public:
@@ -884,11 +928,11 @@ public:
         return TestBlockValidity(state, chainman().GetParams(), chainman().ActiveChainstate(), block, tip, /*fCheckPOW=*/false, check_merkle_root);
     }
 
-    std::unique_ptr<CBlockTemplate> createNewBlock(const CScript& script_pub_key, const BlockCreateOptions& options) override
+    std::unique_ptr<BlockTemplate> createNewBlock(const CScript& script_pub_key, const BlockCreateOptions& options) override
     {
         BlockAssembler::Options assemble_options{options};
         ApplyArgsManOptions(*Assert(m_node.args), assemble_options);
-        return BlockAssembler{chainman().ActiveChainstate(), context()->mempool.get(), assemble_options}.CreateNewBlock(script_pub_key);
+        return std::make_unique<BlockTemplateImpl>(BlockAssembler{chainman().ActiveChainstate(), context()->mempool.get(), assemble_options}.CreateNewBlock(script_pub_key));
     }
 
     NodeContext* context() override { return &m_node; }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -8,6 +8,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <common/args.h>
+#include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
 #include <external_signer.h>
@@ -877,6 +878,11 @@ public:
     int getWitnessCommitmentIndex() override
     {
         return GetWitnessCommitmentIndex(m_block_template->block);
+    }
+
+    std::vector<uint256> getCoinbaseMerklePath() override
+    {
+        return GetCoinBaseMerklePath(m_block_template->block);
     }
 
     std::unique_ptr<CBlockTemplate> m_block_template;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -843,7 +843,7 @@ public:
 class BlockTemplateImpl : public BlockTemplate
 {
 public:
-    explicit BlockTemplateImpl(std::unique_ptr<CBlockTemplate> block_template) : m_block_template(std::move(block_template)) {}
+    explicit BlockTemplateImpl(std::unique_ptr<CBlockTemplate> block_template, NodeContext& node) : m_block_template(std::move(block_template)), m_node(node) {}
 
     CBlockHeader getBlockHeader() override
     {
@@ -885,7 +885,32 @@ public:
         return GetCoinBaseMerklePath(m_block_template->block);
     }
 
+    bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CMutableTransaction coinbase) override
+    {
+        CBlock block{m_block_template->block};
+
+        auto cb = MakeTransactionRef(std::move(coinbase));
+
+        if (block.vtx.size() == 0) {
+            block.vtx.push_back(cb);
+        } else {
+            block.vtx[0] = cb;
+        }
+
+        block.nVersion = version;
+        block.nTime = timestamp;
+        block.nNonce = nonce;
+
+        block.hashMerkleRoot = BlockMerkleRoot(block);
+
+        auto block_ptr = std::make_shared<const CBlock>(block);
+        return chainman().ProcessNewBlock(block_ptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/nullptr);
+    }
+
     std::unique_ptr<CBlockTemplate> m_block_template;
+
+    ChainstateManager& chainman() { return *Assert(m_node.chainman); }
+    NodeContext& m_node;
 };
 
 class MinerImpl : public Mining
@@ -938,7 +963,7 @@ public:
     {
         BlockAssembler::Options assemble_options{options};
         ApplyArgsManOptions(*Assert(m_node.args), assemble_options);
-        return std::make_unique<BlockTemplateImpl>(BlockAssembler{chainman().ActiveChainstate(), context()->mempool.get(), assemble_options}.CreateNewBlock(script_pub_key));
+        return std::make_unique<BlockTemplateImpl>(BlockAssembler{chainman().ActiveChainstate(), context()->mempool.get(), assemble_options}.CreateNewBlock(script_pub_key), m_node);
     }
 
     NodeContext* context() override { return &m_node; }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -955,6 +955,28 @@ public:
         return std::make_pair(chainman().ActiveChain().Tip()->GetBlockHash(), chainman().ActiveChain().Tip()->nHeight);
     }
 
+    bool waitFeesChanged(MillisecondsDouble timeout, uint256 tip, CAmount fee_delta, CAmount& fees_before, bool& tip_changed) override
+    {
+        Assume(getTipHash());
+        unsigned int last_mempool_update{context()->mempool->GetTransactionsUpdated()};
+
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        {
+            while (!chainman().m_interrupt && std::chrono::steady_clock::now() < deadline) {
+                std::this_thread::sleep_for(std::min(timeout, MillisecondsDouble(100)));
+                if (getTipHash().value() != tip) {
+                    tip_changed = true;
+                    return false;
+                }
+
+                // TODO: when cluster mempool is available, actually calculate
+                // fees for the next block. This is currently too expensive.
+                if (context()->mempool->GetTransactionsUpdated() > last_mempool_update) return true;
+            }
+        }
+        return false;
+    }
+
     bool processNewBlock(const std::shared_ptr<const CBlock>& block, bool* new_block) override
     {
         return chainman().ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/new_block);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -885,7 +885,7 @@ public:
         return GetCoinBaseMerklePath(m_block_template->block);
     }
 
-    bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CMutableTransaction coinbase) override
+    bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CMutableTransaction coinbase, uint256& new_block_hash) override
     {
         CBlock block{m_block_template->block};
 
@@ -904,6 +904,7 @@ public:
         block.hashMerkleRoot = BlockMerkleRoot(block);
 
         auto block_ptr = std::make_shared<const CBlock>(block);
+        new_block_hash = block.GetHash();
         return chainman().ProcessNewBlock(block_ptr, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/nullptr);
     }
 

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -166,7 +166,10 @@ public:
     explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn);
+    // TODO:
+    // - implement parent_tp
+    // - add param to request an empty block (on top of parent_tp)
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, std::unique_ptr<CBlockTemplate>parent_tp = nullptr);
 
     inline static std::optional<int64_t> m_last_block_num_txs{};
     inline static std::optional<int64_t> m_last_block_weight{};

--- a/src/node/sv2_template_provider.cpp
+++ b/src/node/sv2_template_provider.cpp
@@ -1,0 +1,98 @@
+#include <node/sv2_template_provider.h>
+
+#include <base58.h>
+#include <crypto/hex_base.h>
+#include <common/args.h>
+#include <common/sv2_noise.h>
+#include <logging.h>
+#include <util/strencodings.h>
+#include <util/thread.h>
+#include <validation.h>
+
+Sv2TemplateProvider::Sv2TemplateProvider(interfaces::Mining& mining) : m_mining{mining}
+{
+    // TODO: persist static key
+    CKey static_key;
+    static_key.MakeNewKey(true);
+
+    auto authority_key{GenerateRandomKey()};
+
+    // SRI uses base58 encoded x-only pubkeys in its configuration files
+    std::array<unsigned char, 34> version_pubkey_bytes;
+    version_pubkey_bytes[0] = 1;
+    version_pubkey_bytes[1] = 0;
+    m_authority_pubkey = XOnlyPubKey(authority_key.GetPubKey());
+    std::copy(m_authority_pubkey.begin(), m_authority_pubkey.end(), version_pubkey_bytes.begin() + 2);
+    LogInfo("Template Provider authority key: %s\n", EncodeBase58Check(version_pubkey_bytes));
+    LogTrace(BCLog::SV2, "Authority key: %s\n", HexStr(m_authority_pubkey));
+
+    // Generate and sign certificate
+    auto now{GetTime<std::chrono::seconds>()};
+    uint16_t version = 0;
+    // Start validity a little bit in the past to account for clock difference
+    uint32_t valid_from = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(now).count()) - 3600;
+    uint32_t valid_to =  std::numeric_limits<unsigned int>::max(); // 2106
+    Sv2SignatureNoiseMessage certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to, XOnlyPubKey(static_key.GetPubKey()), authority_key);
+
+    // TODO: persist certificate
+
+    m_connman = std::make_unique<Sv2Connman>(TP_SUBPROTOCOL, static_key, m_authority_pubkey, certificate);
+
+    // Suppress unused variable warning, result is unused.
+    m_mining.getTipHash();
+}
+
+bool Sv2TemplateProvider::Start(const Sv2TemplateProviderOptions& options)
+{
+    m_options = options;
+
+    if (!m_connman->Start(this, m_options.host, m_options.port)) {
+        return false;
+    }
+
+    m_thread_sv2_handler = std::thread(&util::TraceThread, "sv2", [this] { ThreadSv2Handler(); });
+    return true;
+}
+
+Sv2TemplateProvider::~Sv2TemplateProvider()
+{
+    AssertLockNotHeld(m_tp_mutex);
+
+    m_connman->Interrupt();
+    m_connman->StopThreads();
+
+    Interrupt();
+    StopThreads();
+}
+
+void Sv2TemplateProvider::Interrupt()
+{
+    m_flag_interrupt_sv2 = true;
+}
+
+void Sv2TemplateProvider::StopThreads()
+{
+    if (m_thread_sv2_handler.joinable()) {
+        m_thread_sv2_handler.join();
+    }
+}
+
+void Sv2TemplateProvider::ThreadSv2Handler()
+{
+    while (!m_flag_interrupt_sv2) {
+        // TODO: handle messages
+    }
+}
+
+void Sv2TemplateProvider::ReceivedMessage(Sv2Client& client, node::Sv2MsgType msg_type) {
+    switch (msg_type)
+    {
+    case node::Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE:
+    {
+        LOCK(m_tp_mutex);
+        // TODO: Send new template and prevout
+        break;
+    }
+    default: {}
+    }
+}

--- a/src/node/sv2_template_provider.cpp
+++ b/src/node/sv2_template_provider.cpp
@@ -137,12 +137,21 @@ void Sv2TemplateProvider::RequestTransactionData(Sv2Client& client, node::Sv2Req
     if (cached_block != m_block_template_cache.end()) {
         CBlock block = (*cached_block->second).getBlock();
 
+        if (block.hashPrevBlock != m_best_prev_hash) {
+            LogTrace(BCLog::SV2, "Template id=%lu prevhash=%s, tip=%s\n", msg.m_template_id, HexStr(block.hashPrevBlock), HexStr(m_best_prev_hash));
+            node::Sv2RequestTransactionDataErrorMsg request_tx_data_error{msg.m_template_id, "stale-template-id"};
+
+
+            LogDebug(BCLog::SV2, "Send 0x75 RequestTransactionData.Error (stale-template-id) to client id=%zu\n",
+                    client.m_id);
+            client.m_send_messages.emplace_back(request_tx_data_error);
+            return;
+        }
+
         std::vector<uint8_t> witness_reserve_value;
-        if (!block.IsNull()) {
-            auto scriptWitness = block.vtx[0]->vin[0].scriptWitness;
-            if (!scriptWitness.IsNull()) {
-                std::copy(scriptWitness.stack[0].begin(), scriptWitness.stack[0].end(), std::back_inserter(witness_reserve_value));
-            }
+        auto scriptWitness = block.vtx[0]->vin[0].scriptWitness;
+        if (!scriptWitness.IsNull()) {
+            std::copy(scriptWitness.stack[0].begin(), scriptWitness.stack[0].end(), std::back_inserter(witness_reserve_value));
         }
         std::vector<CTransactionRef> txs;
         if (block.vtx.size() > 0) {

--- a/src/node/sv2_template_provider.cpp
+++ b/src/node/sv2_template_provider.cpp
@@ -1,6 +1,7 @@
 #include <node/sv2_template_provider.h>
 
 #include <base58.h>
+#include <consensus/merkle.h>
 #include <crypto/hex_base.h>
 #include <common/args.h>
 #include <common/sv2_noise.h>
@@ -170,6 +171,31 @@ void Sv2TemplateProvider::RequestTransactionData(Sv2Client& client, node::Sv2Req
                 msg.m_template_id, client.m_id);
         client.m_send_messages.emplace_back(request_tx_data_error);
     }
+}
+
+void Sv2TemplateProvider::SubmitSolution(node::Sv2SubmitSolutionMsg solution)
+{
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "version=%d, timestamp=%d, nonce=%d\n",
+            solution.m_version,
+            solution.m_header_timestamp,
+            solution.m_header_nonce
+        );
+
+        std::unique_ptr<BlockTemplate> block_template;
+        {
+            // We can't hold this lock until submitSolution() because it's
+            // possible that the new block arrives via the p2p network at the
+            // same time. That leads to a deadlock in g_best_block_mutex.
+            LOCK(m_tp_mutex);
+            auto cached_block_template = m_block_template_cache.find(solution.m_template_id);
+            if (cached_block_template == m_block_template_cache.end()) {
+                LogPrintLevel(BCLog::SV2, BCLog::Level::Debug, "Template with id=%lu is no longer in cache\n",
+                solution.m_template_id);
+            }
+            block_template = std::move(cached_block_template->second);
+        }
+
+        block_template->submitSolution(solution.m_version, solution.m_header_timestamp, solution.m_header_nonce, solution.m_coinbase_tx);
 }
 
 Sv2TemplateProvider::NewWorkSet Sv2TemplateProvider::BuildNewWorkSet(bool future_template, unsigned int coinbase_output_max_additional_size)

--- a/src/node/sv2_template_provider.h
+++ b/src/node/sv2_template_provider.h
@@ -128,6 +128,8 @@ public:
 
     void RequestTransactionData(Sv2Client& client, node::Sv2RequestTransactionDataMsg msg) EXCLUSIVE_LOCKS_REQUIRED(!m_tp_mutex) override;
 
+    void SubmitSolution(node::Sv2SubmitSolutionMsg solution) EXCLUSIVE_LOCKS_REQUIRED(!m_tp_mutex) override;
+
     /* Block templates that connected clients may be working on, only used for tests */
     BlockTemplateCache& GetBlockTemplates() EXCLUSIVE_LOCKS_REQUIRED(m_tp_mutex) { return m_block_template_cache; }
 

--- a/src/node/sv2_template_provider.h
+++ b/src/node/sv2_template_provider.h
@@ -126,6 +126,8 @@ public:
 
     void ReceivedMessage(Sv2Client& client, node::Sv2MsgType msg_type) EXCLUSIVE_LOCKS_REQUIRED(!m_tp_mutex) override;
 
+    void RequestTransactionData(Sv2Client& client, node::Sv2RequestTransactionDataMsg msg) EXCLUSIVE_LOCKS_REQUIRED(!m_tp_mutex) override;
+
     /* Block templates that connected clients may be working on, only used for tests */
     BlockTemplateCache& GetBlockTemplates() EXCLUSIVE_LOCKS_REQUIRED(m_tp_mutex) { return m_block_template_cache; }
 

--- a/src/node/sv2_template_provider.h
+++ b/src/node/sv2_template_provider.h
@@ -1,0 +1,104 @@
+#ifndef BITCOIN_NODE_SV2_TEMPLATE_PROVIDER_H
+#define BITCOIN_NODE_SV2_TEMPLATE_PROVIDER_H
+
+#include <interfaces/mining.h>
+#include <common/sv2_connman.h>
+#include <common/sv2_messages.h>
+#include <common/sv2_transport.h>
+#include <logging.h>
+#include <net.h>
+#include <util/sock.h>
+#include <util/time.h>
+#include <streams.h>
+
+struct Sv2TemplateProviderOptions
+{
+    /**
+     * Host for the server to bind to.
+     */
+    std::string host{"127.0.0.1"};
+
+    /**
+     * The listening port for the server.
+     */
+    uint16_t port{8336};
+};
+
+/**
+ * The main class that runs the template provider server.
+ */
+class Sv2TemplateProvider : public Sv2EventsInterface
+{
+
+private:
+    /**
+    * The Mining interface is used to build new valid blocks, get the best known
+    * block hash and to check whether the node is still in IBD.
+    */
+    interfaces::Mining& m_mining;
+
+    /*
+     * The template provider subprotocol used in setup connection messages. The stratum v2
+     * template provider only recognizes its own subprotocol.
+     */
+    static constexpr uint8_t TP_SUBPROTOCOL{0x02};
+
+    std::unique_ptr<Sv2Connman> m_connman;
+
+    /**
+    * Configuration
+    */
+    Sv2TemplateProviderOptions m_options;
+
+    /**
+     * The main thread for the template provider.
+     */
+    std::thread m_thread_sv2_handler;
+
+    /**
+     * Signal for handling interrupts and stopping the template provider event loop.
+     */
+    std::atomic<bool> m_flag_interrupt_sv2{false};
+    CThreadInterrupt m_interrupt_sv2;
+
+public:
+    explicit Sv2TemplateProvider(interfaces::Mining& mining);
+
+    ~Sv2TemplateProvider() EXCLUSIVE_LOCKS_REQUIRED(!m_tp_mutex);
+
+    Mutex m_tp_mutex;
+
+    /**
+     * Starts the template provider server and thread.
+     * returns false if port is unable to bind.
+     */
+    [[nodiscard]] bool Start(const Sv2TemplateProviderOptions& options = {});
+
+    /**
+     * The main thread for the template provider, contains an event loop handling
+     * all tasks for the template provider.
+     */
+    void ThreadSv2Handler();
+
+    /**
+     * Triggered on interrupt signals to stop the main event loop in ThreadSv2Handler().
+     */
+    void Interrupt();
+
+    /**
+     * Tear down of the template provider thread and any other necessary tear down.
+     */
+    void StopThreads();
+
+    /**
+     * Main handler for all received stratum v2 messages.
+     */
+    void ProcessSv2Message(const node::Sv2NetMsg& sv2_header, Sv2Client& client);
+
+    // Only used for tests
+    XOnlyPubKey m_authority_pubkey;
+
+    void ReceivedMessage(Sv2Client& client, node::Sv2MsgType msg_type) EXCLUSIVE_LOCKS_REQUIRED(!m_tp_mutex) override;
+};
+
+#endif // BITCOIN_NODE_SV2_TEMPLATE_PROVIDER_H

--- a/src/node/sv2_template_provider.h
+++ b/src/node/sv2_template_provider.h
@@ -59,6 +59,12 @@ private:
 
     std::unique_ptr<Sv2Connman> m_connman;
 
+    /** Get name of file to store static key */
+    fs::path GetStaticKeyFile();
+
+    /** Get name of file to store authority key */
+    fs::path GetAuthorityKeyFile();
+
     /**
     * Configuration
     */

--- a/src/node/sv2_template_provider.h
+++ b/src/node/sv2_template_provider.h
@@ -1,15 +1,19 @@
 #ifndef BITCOIN_NODE_SV2_TEMPLATE_PROVIDER_H
 #define BITCOIN_NODE_SV2_TEMPLATE_PROVIDER_H
 
-#include <interfaces/mining.h>
+#include <chrono>
 #include <common/sv2_connman.h>
 #include <common/sv2_messages.h>
 #include <common/sv2_transport.h>
+#include <interfaces/mining.h>
 #include <logging.h>
 #include <net.h>
+#include <node/miner.h>
 #include <util/sock.h>
 #include <util/time.h>
 #include <streams.h>
+
+using interfaces::BlockTemplate;
 
 struct Sv2TemplateProviderOptions
 {
@@ -61,6 +65,28 @@ private:
     std::atomic<bool> m_flag_interrupt_sv2{false};
     CThreadInterrupt m_interrupt_sv2;
 
+    /**
+     * The most recent template id. This is incremented on creating new template,
+     * which happens for each connected client.
+     */
+    uint64_t m_template_id GUARDED_BY(m_tp_mutex){0};
+
+    /**
+     * The current best known block hash in the network.
+     */
+    uint256 m_best_prev_hash GUARDED_BY(m_tp_mutex){uint256(0)};
+
+    /** When we last saw a new block connection. Used to cache stale templates
+      * for some time after this.
+      */
+    std::chrono::nanoseconds m_last_block_time GUARDED_BY(m_tp_mutex);
+
+    /**
+     * A cache that maps ids used in NewTemplate messages and its associated block template.
+     */
+    using BlockTemplateCache = std::map<uint64_t, std::unique_ptr<BlockTemplate>>;
+    BlockTemplateCache m_block_template_cache GUARDED_BY(m_tp_mutex);
+
 public:
     explicit Sv2TemplateProvider(interfaces::Mining& mining);
 
@@ -78,7 +104,7 @@ public:
      * The main thread for the template provider, contains an event loop handling
      * all tasks for the template provider.
      */
-    void ThreadSv2Handler();
+    void ThreadSv2Handler() EXCLUSIVE_LOCKS_REQUIRED(!m_tp_mutex);
 
     /**
      * Triggered on interrupt signals to stop the main event loop in ThreadSv2Handler().
@@ -93,12 +119,41 @@ public:
     /**
      * Main handler for all received stratum v2 messages.
      */
-    void ProcessSv2Message(const node::Sv2NetMsg& sv2_header, Sv2Client& client);
+    void ProcessSv2Message(const node::Sv2NetMsg& sv2_header, Sv2Client& client) EXCLUSIVE_LOCKS_REQUIRED(!m_tp_mutex);
 
     // Only used for tests
     XOnlyPubKey m_authority_pubkey;
 
     void ReceivedMessage(Sv2Client& client, node::Sv2MsgType msg_type) EXCLUSIVE_LOCKS_REQUIRED(!m_tp_mutex) override;
+
+    /* Block templates that connected clients may be working on, only used for tests */
+    BlockTemplateCache& GetBlockTemplates() EXCLUSIVE_LOCKS_REQUIRED(m_tp_mutex) { return m_block_template_cache; }
+
+private:
+
+    /**
+     * NewWorkSet contains the messages matching block for valid stratum v2 work.
+     */
+    struct NewWorkSet
+    {
+        node::Sv2NewTemplateMsg new_template;
+        std::unique_ptr<BlockTemplate> block_template;
+        node::Sv2SetNewPrevHashMsg prev_hash;
+    };
+
+    /**
+     * Builds a NewWorkSet that contains the Sv2NewTemplateMsg, a new full block and a Sv2SetNewPrevHashMsg that are all linked to the same work.
+     */
+    [[nodiscard]] NewWorkSet BuildNewWorkSet(bool future_template, unsigned int coinbase_output_max_additional_size) EXCLUSIVE_LOCKS_REQUIRED(m_tp_mutex);
+
+    /* Forget templates from before the last block, but with a few seconds margin. */
+    void PruneBlockTemplateCache() EXCLUSIVE_LOCKS_REQUIRED(m_tp_mutex);
+
+    /**
+     * Sends the best NewTemplate and SetNewPrevHash to a client.
+     */
+    [[nodiscard]] bool SendWork(Sv2Client& client, bool send_new_prevhash) EXCLUSIVE_LOCKS_REQUIRED(m_tp_mutex);
+
 };
 
 #endif // BITCOIN_NODE_SV2_TEMPLATE_PROVIDER_H

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -319,7 +319,7 @@ public:
     /** Construct a new ellswift public key from a given serialization. */
     EllSwiftPubKey(Span<const std::byte> ellswift) noexcept;
 
-    /** Decode to normal compressed CPubKey (for debugging purposes). */
+    /** Decode to normal compressed CPubKey. */
     CPubKey Decode() const;
 
     // Read-only access for serialization.

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -50,6 +50,7 @@ static const int TOOLTIP_WRAP_THRESHOLD = 80;
 #define QAPP_ORG_DOMAIN "bitcoin.org"
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+#define QAPP_APP_NAME_TESTNET4 "Bitcoin-Qt-testnet4"
 #define QAPP_APP_NAME_SIGNET "Bitcoin-Qt-signet"
 #define QAPP_APP_NAME_REGTEST "Bitcoin-Qt-regtest"
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -117,6 +117,7 @@ static std::string DummyAddress(const CChainParams &params)
         break;
     case ChainType::SIGNET:
     case ChainType::TESTNET:
+    case ChainType::TESTNET4:
         addr = "tb1p35yvjel7srp783ztf8v6jdra7dhfzk5jaun8xz2qp6ws7z80n4tqa6qnlg";
         break;
     case ChainType::REGTEST:

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -19,6 +19,7 @@ static const struct {
 } network_styles[] = {
     {ChainType::MAIN, QAPP_APP_NAME_DEFAULT, 0, 0},
     {ChainType::TESTNET, QAPP_APP_NAME_TESTNET, 70, 30},
+    {ChainType::TESTNET4, QAPP_APP_NAME_TESTNET4, 70, 30},
     {ChainType::SIGNET, QAPP_APP_NAME_SIGNET, 35, 15},
     {ChainType::REGTEST, QAPP_APP_NAME_REGTEST, 160, 30},
 };

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -45,7 +45,7 @@
 #include <stdint.h>
 
 using node::BlockAssembler;
-using node::CBlockTemplate;
+using interfaces::BlockTemplate;
 using interfaces::Mining;
 using node::NodeContext;
 using node::RegenerateCommitments;
@@ -129,7 +129,7 @@ static RPCHelpMan getnetworkhashps()
     };
 }
 
-static bool GenerateBlock(ChainstateManager& chainman, Mining& miner, CBlock& block, uint64_t& max_tries, std::shared_ptr<const CBlock>& block_out, bool process_new_block)
+static bool GenerateBlock(ChainstateManager& chainman, Mining& miner, CBlock&& block, uint64_t& max_tries, std::shared_ptr<const CBlock>& block_out, bool process_new_block)
 {
     block_out.reset();
     block.hashMerkleRoot = BlockMerkleRoot(block);
@@ -160,12 +160,12 @@ static UniValue generateBlocks(ChainstateManager& chainman, Mining& miner, const
 {
     UniValue blockHashes(UniValue::VARR);
     while (nGenerate > 0 && !chainman.m_interrupt) {
-        std::unique_ptr<CBlockTemplate> pblocktemplate(miner.createNewBlock(coinbase_script));
-        if (!pblocktemplate.get())
+        std::unique_ptr<BlockTemplate> block_template(miner.createNewBlock(coinbase_script));
+        if (!block_template.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
 
         std::shared_ptr<const CBlock> block_out;
-        if (!GenerateBlock(chainman, miner, pblocktemplate->block, nMaxTries, block_out, /*process_new_block=*/true)) {
+        if (!GenerateBlock(chainman, miner, block_template->getBlock(), nMaxTries, block_out, /*process_new_block=*/true)) {
             break;
         }
 
@@ -371,11 +371,11 @@ static RPCHelpMan generateblock()
 
     ChainstateManager& chainman = EnsureChainman(node);
     {
-        std::unique_ptr<CBlockTemplate> blocktemplate{miner.createNewBlock(coinbase_script, {.use_mempool = false})};
-        if (!blocktemplate) {
+        std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock(coinbase_script, {.use_mempool = false})};
+        if (!block_template) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         }
-        block = blocktemplate->block;
+        block = block_template->getBlock();
     }
 
     CHECK_NONFATAL(block.vtx.size() == 1);
@@ -394,7 +394,7 @@ static RPCHelpMan generateblock()
     std::shared_ptr<const CBlock> block_out;
     uint64_t max_tries{DEFAULT_MAX_TRIES};
 
-    if (!GenerateBlock(chainman, miner, block, max_tries, block_out, process_new_block) || !block_out) {
+    if (!GenerateBlock(chainman, miner, std::move(block), max_tries, block_out, process_new_block) || !block_out) {
         throw JSONRPCError(RPC_MISC_ERROR, "Failed to make block.");
     }
 
@@ -800,7 +800,7 @@ static RPCHelpMan getblocktemplate()
     // Update block
     static CBlockIndex* pindexPrev;
     static int64_t time_start;
-    static std::unique_ptr<CBlockTemplate> pblocktemplate;
+    static std::unique_ptr<BlockTemplate> block_template;
     if (!pindexPrev || pindexPrev->GetBlockHash() != tip ||
         (miner.getTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - time_start > 5))
     {
@@ -814,8 +814,8 @@ static RPCHelpMan getblocktemplate()
 
         // Create new block
         CScript scriptDummy = CScript() << OP_TRUE;
-        pblocktemplate = miner.createNewBlock(scriptDummy);
-        if (!pblocktemplate) {
+        block_template = miner.createNewBlock(scriptDummy);
+        if (!block_template) {
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
         }
 
@@ -823,11 +823,11 @@ static RPCHelpMan getblocktemplate()
         pindexPrev = pindexPrevNew;
     }
     CHECK_NONFATAL(pindexPrev);
-    CBlock* pblock = &pblocktemplate->block; // pointer for convenience
+    CBlock block{block_template->getBlock()};
 
     // Update nTime
-    UpdateTime(pblock, consensusParams, pindexPrev);
-    pblock->nNonce = 0;
+    UpdateTime(&block, consensusParams, pindexPrev);
+    block.nNonce = 0;
 
     // NOTE: If at some point we support pre-segwit miners post-segwit-activation, this needs to take segwit support into consideration
     const bool fPreSegWit = !DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT);
@@ -836,8 +836,11 @@ static RPCHelpMan getblocktemplate()
 
     UniValue transactions(UniValue::VARR);
     std::map<uint256, int64_t> setTxIndex;
+    std::vector<CAmount> tx_fees{block_template->getTxFees()};
+    std::vector<CAmount> tx_sigops{block_template->getTxSigops()};
+
     int i = 0;
-    for (const auto& it : pblock->vtx) {
+    for (const auto& it : block.vtx) {
         const CTransaction& tx = *it;
         uint256 txHash = tx.GetHash();
         setTxIndex[txHash] = i++;
@@ -860,8 +863,8 @@ static RPCHelpMan getblocktemplate()
         entry.pushKV("depends", std::move(deps));
 
         int index_in_template = i - 1;
-        entry.pushKV("fee", pblocktemplate->vTxFees[index_in_template]);
-        int64_t nTxSigOps = pblocktemplate->vTxSigOpsCost[index_in_template];
+        entry.pushKV("fee", tx_fees.at(index_in_template));
+        int64_t nTxSigOps{tx_sigops.at(index_in_template)};
         if (fPreSegWit) {
             CHECK_NONFATAL(nTxSigOps % WITNESS_SCALE_FACTOR == 0);
             nTxSigOps /= WITNESS_SCALE_FACTOR;
@@ -874,7 +877,7 @@ static RPCHelpMan getblocktemplate()
 
     UniValue aux(UniValue::VOBJ);
 
-    arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
+    arith_uint256 hashTarget = arith_uint256().SetCompact(block.nBits);
 
     UniValue aMutable(UniValue::VARR);
     aMutable.push_back("time");
@@ -904,7 +907,7 @@ static RPCHelpMan getblocktemplate()
                 break;
             case ThresholdState::LOCKED_IN:
                 // Ensure bit is set in block version
-                pblock->nVersion |= chainman.m_versionbitscache.Mask(consensusParams, pos);
+                block.nVersion |= chainman.m_versionbitscache.Mask(consensusParams, pos);
                 [[fallthrough]];
             case ThresholdState::STARTED:
             {
@@ -913,7 +916,7 @@ static RPCHelpMan getblocktemplate()
                 if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
                     if (!vbinfo.gbt_force) {
                         // If the client doesn't support this, don't indicate it in the [default] version
-                        pblock->nVersion &= ~chainman.m_versionbitscache.Mask(consensusParams, pos);
+                        block.nVersion &= ~chainman.m_versionbitscache.Mask(consensusParams, pos);
                     }
                 }
                 break;
@@ -933,15 +936,15 @@ static RPCHelpMan getblocktemplate()
             }
         }
     }
-    result.pushKV("version", pblock->nVersion);
+    result.pushKV("version", block.nVersion);
     result.pushKV("rules", std::move(aRules));
     result.pushKV("vbavailable", std::move(vbavailable));
     result.pushKV("vbrequired", int(0));
 
-    result.pushKV("previousblockhash", pblock->hashPrevBlock.GetHex());
+    result.pushKV("previousblockhash", block.hashPrevBlock.GetHex());
     result.pushKV("transactions", std::move(transactions));
     result.pushKV("coinbaseaux", std::move(aux));
-    result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
+    result.pushKV("coinbasevalue", (int64_t)block.vtx[0]->vout[0].nValue);
     result.pushKV("longpollid", tip.GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
@@ -960,16 +963,16 @@ static RPCHelpMan getblocktemplate()
     if (!fPreSegWit) {
         result.pushKV("weightlimit", (int64_t)MAX_BLOCK_WEIGHT);
     }
-    result.pushKV("curtime", pblock->GetBlockTime());
-    result.pushKV("bits", strprintf("%08x", pblock->nBits));
+    result.pushKV("curtime", block.GetBlockTime());
+    result.pushKV("bits", strprintf("%08x", block.nBits));
     result.pushKV("height", (int64_t)(pindexPrev->nHeight+1));
 
     if (consensusParams.signet_blocks) {
         result.pushKV("signet_challenge", HexStr(consensusParams.signet_challenge));
     }
 
-    if (!pblocktemplate->vchCoinbaseCommitment.empty()) {
-        result.pushKV("default_witness_commitment", HexStr(pblocktemplate->vchCoinbaseCommitment));
+    if (!block_template->getCoinbaseCommitment().empty()) {
+        result.pushKV("default_witness_commitment", HexStr(block_template->getCoinbaseCommitment()));
     }
 
     return result;

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -644,10 +644,12 @@ BOOST_AUTO_TEST_CASE(util_GetChainTypeString)
 {
     TestArgsManager test_args;
     const auto testnet = std::make_pair("-testnet", ArgsManager::ALLOW_ANY);
+    const auto testnet4 = std::make_pair("-testnet4", ArgsManager::ALLOW_ANY);
     const auto regtest = std::make_pair("-regtest", ArgsManager::ALLOW_ANY);
-    test_args.SetupArgs({testnet, regtest});
+    test_args.SetupArgs({testnet, testnet4, regtest});
 
     const char* argv_testnet[] = {"cmd", "-testnet"};
+    const char* argv_testnet4[] = {"cmd", "-testnet4"};
     const char* argv_regtest[] = {"cmd", "-regtest"};
     const char* argv_test_no_reg[] = {"cmd", "-testnet", "-noregtest"};
     const char* argv_both[] = {"cmd", "-testnet", "-regtest"};
@@ -662,6 +664,12 @@ BOOST_AUTO_TEST_CASE(util_GetChainTypeString)
 
     BOOST_CHECK(test_args.ParseParameters(2, argv_testnet, error));
     BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "test");
+
+    BOOST_CHECK(test_args.ParseParameters(0, argv_testnet4, error));
+    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "main");
+
+    BOOST_CHECK(test_args.ParseParameters(2, argv_testnet4, error));
+    BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "testnet4");
 
     BOOST_CHECK(test_args.ParseParameters(2, argv_regtest, error));
     BOOST_CHECK_EQUAL(test_args.GetChainTypeString(), "regtest");
@@ -758,8 +766,8 @@ struct ArgsMergeTestingSetup : public BasicTestingSetup {
             ForEachNoDup(conf_actions, SET, SECTION_NEGATE, [&] {
                 for (bool soft_set : {false, true}) {
                     for (bool force_set : {false, true}) {
-                        for (const std::string& section : {ChainTypeToString(ChainType::MAIN), ChainTypeToString(ChainType::TESTNET), ChainTypeToString(ChainType::SIGNET)}) {
-                            for (const std::string& network : {ChainTypeToString(ChainType::MAIN), ChainTypeToString(ChainType::TESTNET), ChainTypeToString(ChainType::SIGNET)}) {
+                        for (const std::string& section : {ChainTypeToString(ChainType::MAIN), ChainTypeToString(ChainType::TESTNET), ChainTypeToString(ChainType::TESTNET4), ChainTypeToString(ChainType::SIGNET)}) {
+                            for (const std::string& network : {ChainTypeToString(ChainType::MAIN), ChainTypeToString(ChainType::TESTNET), ChainTypeToString(ChainType::TESTNET4), ChainTypeToString(ChainType::SIGNET)}) {
                                 for (bool net_specific : {false, true}) {
                                     fn(arg_actions, conf_actions, soft_set, force_set, section, network, net_specific);
                                 }
@@ -913,7 +921,7 @@ BOOST_FIXTURE_TEST_CASE(util_ArgsMerge, ArgsMergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || <IsArgSet/IsArgNegated/GetArg output> | <GetArgs output> | <GetUnsuitable output>
-    BOOST_CHECK_EQUAL(out_sha_hex, "d1e436c1cd510d0ec44d5205d4b4e3bee6387d316e0075c58206cb16603f3d82");
+    BOOST_CHECK_EQUAL(out_sha_hex, "f1ee5ab094cc43d16a6086fa7f2c10389e0f99902616b31bbf29189972ad1473");
 }
 
 // Similar test as above, but for ArgsManager::GetChainTypeString function.
@@ -1016,7 +1024,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || <output>
-    BOOST_CHECK_EQUAL(out_sha_hex, "f263493e300023b6509963887444c41386f44b63bc30047eb8402e8c1144854c");
+    BOOST_CHECK_EQUAL(out_sha_hex, "9e60306e1363528bbc19a47f22bcede88e5d6815212f18ec8e6cdc4638dddab4");
 }
 
 BOOST_AUTO_TEST_CASE(util_ReadWriteSettings)

--- a/src/test/fuzz/sv2_noise.cpp
+++ b/src/test/fuzz/sv2_noise.cpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/sv2_noise.h>
+#include <logging.h>
+#include <random.h>
+#include <span.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+
+#include <cstdint>
+#include <util/vector.h>
+
+namespace {
+
+
+void Initialize()
+{
+    // Add test context for debugging. Usage:
+    // --debug=sv2 --loglevel=sv2:trace --printtoconsole=1
+    static const auto testing_setup = std::make_unique<const BasicTestingSetup>();
+}
+} // namespace
+
+bool MaybeDamage(FuzzedDataProvider& provider, std::vector<std::byte>& transport)
+{
+    if (transport.size() == 0) return false;
+
+    // Optionally damage 1 bit in the ciphertext.
+    const bool damage = provider.ConsumeBool();
+    if (damage) {
+        unsigned damage_bit = provider.ConsumeIntegralInRange<unsigned>(0,
+                                                                        transport.size() * 8U - 1U);
+        unsigned damage_pos = damage_bit >> 3;
+        LogTrace(BCLog::SV2, "Damage byte %d of %d\n", damage_pos, transport.size());
+        std::byte damage_val{(uint8_t)(1U << (damage_bit & 7))};
+        transport.at(damage_pos) ^= damage_val;
+    }
+    return damage;
+}
+
+FUZZ_TARGET(sv2_noise_cipher_roundtrip, .init = Initialize)
+{
+    // Test that Sv2Noise's encryption and decryption agree.
+
+    // To conserve fuzzer entropy, deterministically generate Alice and Bob keys.
+    FuzzedDataProvider provider(buffer.data(), buffer.size());
+    auto seed_ent = provider.ConsumeBytes<std::byte>(32);
+    seed_ent.resize(32);
+    CExtKey seed;
+    seed.SetSeed(seed_ent);
+
+    CExtKey tmp;
+    if (!seed.Derive(tmp, 0)) return;
+    CKey alice_authority_key{tmp.key};
+
+    if (!seed.Derive(tmp, 1)) return;
+    CKey alice_static_key{tmp.key};
+
+    if (!seed.Derive(tmp, 2)) return;
+    CKey alice_ephemeral_key{tmp.key};
+
+    if (!seed.Derive(tmp, 10)) return;
+    CKey bob_authority_key{tmp.key};
+
+    if (!seed.Derive(tmp, 11)) return;
+    CKey bob_static_key{tmp.key};
+
+    if (!seed.Derive(tmp, 12)) return;
+    CKey bob_ephemeral_key{tmp.key};
+
+    // Create certificate
+    // Pick random times in the past or future
+    uint32_t now = provider.ConsumeIntegralInRange<uint32_t>(10000U, UINT32_MAX);
+    SetMockTime(now);
+    uint16_t version = provider.ConsumeBool() ? 0 : provider.ConsumeIntegral<uint16_t>();
+    uint32_t past = provider.ConsumeIntegralInRange<uint32_t>(0, now);
+    uint32_t future = provider.ConsumeIntegralInRange<uint32_t>(now, UINT32_MAX);
+    uint32_t valid_from = int32_t(provider.ConsumeBool() ? past : future);
+    uint32_t valid_to = int32_t(provider.ConsumeBool() ? future : past);
+
+    auto bob_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
+                                                    XOnlyPubKey(bob_static_key.GetPubKey()), bob_authority_key);
+
+    bool valid_certificate = version == 0 &&
+                             (valid_from <= now) &&
+                             (valid_to >= now);
+
+    LogTrace(BCLog::SV2, "valid_certificate: %d - version %u, past: %u, now %u, future: %u\n", valid_certificate, version, past, now, future);
+
+    // Alice's static is not used in the test
+    // Alice needs to verify Bob's certificate, so we pass his authority key
+    auto alice_handshake = std::make_unique<Sv2HandshakeState>(std::move(alice_static_key), XOnlyPubKey(bob_authority_key.GetPubKey()));
+    alice_handshake->SetEphemeralKey(std::move(alice_ephemeral_key));
+    // Bob is the responder and does not receive (or verify) Alice's certificate,
+    // so we don't pass her authority key.
+    auto bob_handshake = std::make_unique<Sv2HandshakeState>(std::move(bob_static_key), std::move(bob_certificate));
+    bob_handshake->SetEphemeralKey(std::move(bob_ephemeral_key));
+
+    // Handshake Act 1: e ->
+
+    std::vector<std::byte> transport;
+    transport.resize(Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE);
+    // Alice generates her ephemeral public key and write it into the buffer:
+    alice_handshake->WriteMsgEphemeralPK(transport);
+
+    bool damage_e = MaybeDamage(provider, transport);
+
+    // Bob reads the ephemeral key ()
+    // With EllSwift encoding this step can't fail
+    bob_handshake->ReadMsgEphemeralPK(transport);
+    ClearShrink(transport);
+
+    // Handshake Act 2: <- e, ee, s, es, SIGNATURE_NOISE_MESSAGE
+    transport.resize(Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+    bob_handshake->WriteMsgES(transport);
+
+    bool damage_es = MaybeDamage(provider, transport);
+
+    // This ignores the remote possibility that the fuzzer finds two equivalent
+    // EllSwift encodings by flipping a single ephemeral key bit.
+    assert(alice_handshake->ReadMsgES(transport) == (valid_certificate && !damage_e && !damage_es));
+
+    if (!valid_certificate || damage_e || damage_es) return;
+
+    // Construct Sv2Cipher from the Sv2HandshakeState and test transport
+    auto alice{Sv2Cipher(/*initiator=*/true, std::move(alice_handshake))};
+    auto bob{Sv2Cipher(/*initiator=*/false, std::move(bob_handshake))};
+    alice.FinishHandshake();
+    bob.FinishHandshake();
+
+    // Use deterministic RNG to generate content rather than creating it from
+    // the fuzzer input.
+    InsecureRandomContext rng(provider.ConsumeIntegral<uint64_t>());
+
+    LIMITED_WHILE(provider.remaining_bytes(), 1000)
+    {
+        ClearShrink(transport);
+
+        // Alice or Bob sends a message
+        bool from_alice = provider.ConsumeBool();
+
+        // Set content length (slightly above NOISE_MAX_CHUNK_SIZE)
+        unsigned length = provider.ConsumeIntegralInRange<unsigned>(0, NOISE_MAX_CHUNK_SIZE + 100);
+        std::vector<std::byte> plain(length);
+        for (auto& val : plain)
+            val = std::byte{(uint8_t)rng()};
+
+        const size_t encrypted_size = Sv2Cipher::EncryptedMessageSize(plain.size());
+        transport.resize(encrypted_size);
+
+        assert((from_alice ? alice : bob).EncryptMessage(plain, transport));
+
+        const bool damage = MaybeDamage(provider, transport);
+
+        std::vector<std::byte> plain_read;
+        plain_read.resize(plain.size());
+
+        bool ok = (from_alice ? bob : alice).DecryptMessage(transport, plain_read);
+        assert(!ok == damage);
+        if (!ok) break;
+
+        assert(plain == plain_read);
+    }
+}

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -345,4 +345,27 @@ BOOST_AUTO_TEST_CASE(bip341_test_h)
     BOOST_CHECK(XOnlyPubKey::NUMS_H == H);
 }
 
+BOOST_AUTO_TEST_CASE(key_serialization)
+{
+    {
+        DataStream s{};
+        CKey key;
+        BOOST_CHECK_EXCEPTION(s << key, std::ios_base::failure,
+                              HasReason{"invalid key"});
+
+        s << MakeByteSpan(std::vector<std::byte>(33, std::byte(0)));
+        BOOST_CHECK_EXCEPTION(s >> key, std::ios_base::failure,
+                              HasReason{"invalid key"});
+    }
+
+    for (bool compressed : {true, false}) {
+        CKey key{GenerateRandomKey(/*compressed=*/compressed)};
+        DataStream s{};
+        s << key;
+        CKey key_copy;
+        s >> key_copy;
+        BOOST_CHECK(key == key_copy);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -198,6 +198,11 @@ BOOST_AUTO_TEST_CASE(ChainParams_TESTNET_sanity)
     sanity_check_chainparams(*m_node.args, ChainType::TESTNET);
 }
 
+BOOST_AUTO_TEST_CASE(ChainParams_TESTNET4_sanity)
+{
+    sanity_check_chainparams(*m_node.args, ChainType::TESTNET4);
+}
+
 BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
 {
     sanity_check_chainparams(*m_node.args, ChainType::SIGNET);

--- a/src/test/sv2_connman_tests.cpp
+++ b/src/test/sv2_connman_tests.cpp
@@ -163,6 +163,10 @@ public:
         BOOST_TEST_MESSAGE("Process RequestTransactionData");
     }
 
+    void SubmitSolution(node::Sv2SubmitSolutionMsg solution) override {
+        BOOST_TEST_MESSAGE("Process SubmitSolution");
+    }
+
 };
 
 BOOST_AUTO_TEST_CASE(client_tests)

--- a/src/test/sv2_connman_tests.cpp
+++ b/src/test/sv2_connman_tests.cpp
@@ -1,0 +1,202 @@
+#include <boost/test/unit_test.hpp>
+#include <common/sv2_connman.h>
+#include <common/sv2_messages.h>
+#include <common/sv2_transport.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+#include <util/sock.h>
+
+#include <memory>
+
+BOOST_FIXTURE_TEST_SUITE(sv2_connman_tests, TestChain100Setup)
+
+/**
+  * A class for testing the Sv2Connman. Each ConnTester encapsulates a
+  * Sv2Connman (the one being tested) as well as a Sv2Cipher
+  * to act as the other side.
+  */
+class ConnTester : Sv2EventsInterface {
+private:
+    std::unique_ptr<Sv2Transport> m_peer_transport; //!< Transport for peer
+    // Sockets that will be returned by the Sv2Connman's listening socket Accept() method.
+    std::shared_ptr<DynSock::Queue> m_sv2connman_accepted_sockets{std::make_shared<DynSock::Queue>()};
+
+    std::shared_ptr<DynSock::Pipes> m_current_client_pipes;
+
+    XOnlyPubKey m_connman_authority_pubkey;
+
+public:
+    std::unique_ptr<Sv2Connman> m_connman; //!< Sv2Connman being tested
+
+    ConnTester()
+    {
+        CreateSock = [this](int, int, int) -> std::unique_ptr<Sock> {
+            // This will be the bind/listen socket from m_connman. It will
+            // create other sockets via its Accept() method.
+            return std::make_unique<DynSock>(std::make_shared<DynSock::Pipes>(), m_sv2connman_accepted_sockets);
+        };
+
+        CKey static_key;
+        static_key.MakeNewKey(true);
+        auto authority_key{GenerateRandomKey()};
+        m_connman_authority_pubkey = XOnlyPubKey(authority_key.GetPubKey());
+
+        // Generate and sign certificate
+        auto now{GetTime<std::chrono::seconds>()};
+        uint16_t version = 0;
+        // Start validity a little bit in the past to account for clock difference
+        uint32_t valid_from = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(now).count()) - 3600;
+        uint32_t valid_to =  std::numeric_limits<unsigned int>::max(); // 2106
+        Sv2SignatureNoiseMessage certificate{version, valid_from, valid_to, XOnlyPubKey(static_key.GetPubKey()), authority_key};
+
+        m_connman = std::make_unique<Sv2Connman>(TP_SUBPROTOCOL, static_key, m_connman_authority_pubkey, certificate);
+
+        BOOST_REQUIRE(m_connman->Start(this, "127.0.0.1", 18447));
+    }
+
+    ~ConnTester()
+    {
+        CreateSock = CreateSockOS;
+    }
+
+    void SendPeerBytes()
+    {
+        const auto& [data, more, _m_message_type] = m_peer_transport->GetBytesToSend(/*have_next_message=*/false);
+        BOOST_REQUIRE(data.size() > 0);
+        // Schedule data to be returned by the next Recv() call from
+        // Sv2Connman on the socket it has accepted.
+        m_current_client_pipes->recv.PushBytes(data.data(), data.size());
+        m_peer_transport->MarkBytesSent(data.size());
+    }
+
+    // Have the peer receive and process bytes:
+    size_t PeerReceiveBytes()
+    {
+        uint8_t buf[0x10000];
+        // Get the data that has been written to the accepted socket with Send() by Sv2Connman.
+        // Wait until the bytes appear in the "send" pipe.
+        ssize_t n;
+        for (;;) {
+            n = m_current_client_pipes->send.GetBytes(buf, sizeof(buf), 0);
+            if (n != -1 || errno != EAGAIN) {
+                break;
+            }
+            UninterruptibleSleep(50ms);
+        }
+
+        // Inform client's transport that some bytes have been received (sent by Sv2Connman).
+        if (n > 0) {
+            Span<const uint8_t> s(buf, n);
+            BOOST_REQUIRE(m_peer_transport->ReceivedBytes(s));
+        }
+
+        return n;
+    }
+
+    /* Create a new client and perform handshake */
+    void handshake()
+    {
+        m_peer_transport.reset();
+
+        auto peer_static_key{GenerateRandomKey()};
+        m_peer_transport = std::make_unique<Sv2Transport>(std::move(peer_static_key), m_connman_authority_pubkey);
+
+        // Have Sv2Connman's listen socket's Accept() simulate a newly arrived connection.
+        m_current_client_pipes = std::make_shared<DynSock::Pipes>();
+        m_sv2connman_accepted_sockets->Push(
+            std::make_unique<DynSock>(m_current_client_pipes, std::make_shared<DynSock::Queue>()));
+
+        // Flush transport for handshake part 1
+        SendPeerBytes();
+
+        // Read handshake part 2 from transport
+        BOOST_REQUIRE_EQUAL(PeerReceiveBytes(), Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+
+        BOOST_REQUIRE(IsConnected());
+    }
+
+    void receiveMessage(Sv2NetMsg& msg)
+    {
+        // Client encrypts message and puts it on the transport:
+        CSerializedNetMsg net_msg{std::move(msg)};
+        BOOST_REQUIRE(m_peer_transport->SetMessageToSend(net_msg));
+        SendPeerBytes();
+    }
+
+    bool IsConnected()
+    {
+        LOCK(m_connman->m_clients_mutex);
+        return m_connman->ConnectedClients() > 0;
+    }
+
+    bool IsFullyConnected()
+    {
+        LOCK(m_connman->m_clients_mutex);
+        return m_connman->FullyConnectedClients() > 0;
+    }
+
+    Sv2NetMsg SetupConnectionMsg()
+    {
+        std::vector<uint8_t> bytes{
+            0x02,                                                 // protocol
+            0x02, 0x00,                                           // min_version
+            0x02, 0x00,                                           // max_version
+            0x01, 0x00, 0x00, 0x00,                               // flags
+            0x07, 0x30, 0x2e, 0x30, 0x2e, 0x30, 0x2e, 0x30,       // endpoint_host
+            0x61, 0x21,                                           // endpoint_port
+            0x07, 0x42, 0x69, 0x74, 0x6d, 0x61, 0x69, 0x6e,       // vendor
+            0x08, 0x53, 0x39, 0x69, 0x20, 0x31, 0x33, 0x2e, 0x35, // hardware_version
+            0x1c, 0x62, 0x72, 0x61, 0x69, 0x69, 0x6e, 0x73, 0x2d, 0x6f, 0x73, 0x2d, 0x32, 0x30,
+            0x31, 0x38, 0x2d, 0x30, 0x39, 0x2d, 0x32, 0x32, 0x2d, 0x31, 0x2d, 0x68, 0x61, 0x73,
+            0x68, // firmware
+            0x10, 0x73, 0x6f, 0x6d, 0x65, 0x2d, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65, 0x2d, 0x75,
+            0x75, 0x69, 0x64, // device_id
+        };
+
+        return node::Sv2NetMsg{node::Sv2MsgType::SETUP_CONNECTION, std::move(bytes)};
+    }
+
+    void ReceivedMessage(Sv2Client& client, node::Sv2MsgType msg_type) override {
+    }
+
+};
+
+BOOST_AUTO_TEST_CASE(client_tests)
+{
+    ConnTester tester{};
+
+    BOOST_REQUIRE(!tester.IsConnected());
+    tester.handshake();
+    BOOST_REQUIRE(!tester.IsFullyConnected());
+
+    // After the handshake the client must send a SetupConnection message to the
+    // Template Provider.
+
+    // An empty SetupConnection message should cause disconnection
+    node::Sv2NetMsg sv2_msg{node::Sv2MsgType::SETUP_CONNECTION, {}};
+    tester.receiveMessage(sv2_msg);
+    BOOST_REQUIRE_EQUAL(tester.PeerReceiveBytes(), 0);
+
+    BOOST_REQUIRE(!tester.IsConnected());
+
+    BOOST_TEST_MESSAGE("Reconnect after empty message");
+
+    // Reconnect
+    tester.handshake();
+    BOOST_TEST_MESSAGE("Handshake done, send SetupConnectionMsg");
+
+    node::Sv2NetMsg setup{tester.SetupConnectionMsg()};
+    tester.receiveMessage(setup);
+    // SetupConnection.Success is 6 bytes
+    BOOST_REQUIRE_EQUAL(tester.PeerReceiveBytes(), SV2_HEADER_ENCRYPTED_SIZE + 6 + Poly1305::TAGLEN);
+    BOOST_REQUIRE(tester.IsFullyConnected());
+
+    std::vector<uint8_t> coinbase_output_max_additional_size_bytes{
+        0x01, 0x00, 0x00, 0x00
+    };
+    node::Sv2NetMsg msg{node::Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE, std::move(coinbase_output_max_additional_size_bytes)};
+    // No reply expected, not yet implemented
+    tester.receiveMessage(msg);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sv2_connman_tests.cpp
+++ b/src/test/sv2_connman_tests.cpp
@@ -159,6 +159,10 @@ public:
     void ReceivedMessage(Sv2Client& client, node::Sv2MsgType msg_type) override {
     }
 
+    void RequestTransactionData(Sv2Client& client, node::Sv2RequestTransactionDataMsg msg) override {
+        BOOST_TEST_MESSAGE("Process RequestTransactionData");
+    }
+
 };
 
 BOOST_AUTO_TEST_CASE(client_tests)

--- a/src/test/sv2_messages_tests.cpp
+++ b/src/test/sv2_messages_tests.cpp
@@ -1,0 +1,100 @@
+#include <boost/test/unit_test.hpp>
+#include <common/sv2_messages.h>
+#include <util/strencodings.h>
+
+BOOST_AUTO_TEST_SUITE(sv2_messages_tests)
+
+BOOST_AUTO_TEST_CASE(Sv2SetupConnection_test)
+{
+    uint8_t input[]{
+        0x02,                                                 // protocol
+        0x02, 0x00,                                           // min_version
+        0x02, 0x00,                                           // max_version
+        0x01, 0x00, 0x00, 0x00,                               // flags
+        0x07, 0x30, 0x2e, 0x30, 0x2e, 0x30, 0x2e, 0x30,       // endpoint_host
+        0x61, 0x21,                                           // endpoint_port
+        0x07, 0x42, 0x69, 0x74, 0x6d, 0x61, 0x69, 0x6e,       // vendor
+        0x08, 0x53, 0x39, 0x69, 0x20, 0x31, 0x33, 0x2e, 0x35, // hardware_version
+        0x1c, 0x62, 0x72, 0x61, 0x69, 0x69, 0x6e, 0x73, 0x2d, 0x6f, 0x73, 0x2d, 0x32, 0x30,
+        0x31, 0x38, 0x2d, 0x30, 0x39, 0x2d, 0x32, 0x32, 0x2d, 0x31, 0x2d, 0x68, 0x61, 0x73,
+        0x68, // firmware
+        0x10, 0x73, 0x6f, 0x6d, 0x65, 0x2d, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65, 0x2d, 0x75,
+        0x75, 0x69, 0x64, // device_id
+    };
+    BOOST_CHECK_EQUAL(sizeof(input), 82);
+
+    DataStream ss(input);
+    BOOST_CHECK_EQUAL(ss.size(), sizeof(input));
+
+    node::Sv2SetupConnectionMsg setup_conn;
+    ss >> setup_conn;
+
+    BOOST_CHECK_EQUAL(setup_conn.m_protocol, 2);
+    BOOST_CHECK_EQUAL(setup_conn.m_min_version, 2);
+    BOOST_CHECK_EQUAL(setup_conn.m_max_version, 2);
+    BOOST_CHECK_EQUAL(setup_conn.m_flags, 1);
+    BOOST_CHECK_EQUAL(setup_conn.m_endpoint_host, "0.0.0.0");
+    BOOST_CHECK_EQUAL(setup_conn.m_endpoint_port, 8545);
+    BOOST_CHECK_EQUAL(setup_conn.m_vendor, "Bitmain");
+    BOOST_CHECK_EQUAL(setup_conn.m_hardware_version, "S9i 13.5");
+    BOOST_CHECK_EQUAL(setup_conn.m_firmware, "braiins-os-2018-09-22-1-hash");
+    BOOST_CHECK_EQUAL(setup_conn.m_device_id, "some-device-uuid");
+}
+
+BOOST_AUTO_TEST_CASE(Sv2NetHeader_SetupConnection_test)
+{
+    uint8_t input[]{
+        0x00, 0x00,       // extension type
+        0x00,             // msg type (SetupConnection)
+        0x52, 0x00, 0x00, // msg length
+    };
+
+    DataStream ss(input);
+    node::Sv2NetHeader sv2_header;
+    ss >> sv2_header;
+
+    BOOST_CHECK(sv2_header.m_msg_type == node::Sv2MsgType::SETUP_CONNECTION);
+    BOOST_CHECK_EQUAL(sv2_header.m_msg_len, 82);
+}
+
+BOOST_AUTO_TEST_CASE(Sv2SetupConnectionSuccess_test)
+{
+    // 0200 - used_version
+    // 03000000 - flags
+    std::string expected{"020003000000"};
+    node::Sv2SetupConnectionSuccessMsg setup_conn_success{2, 3};
+
+    DataStream ss{};
+    ss << setup_conn_success;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+BOOST_AUTO_TEST_CASE(Sv2NetMsg_SetupConnectionSuccess_test)
+{
+    // 0200     - used_version
+    // 03000000 - flags
+    std::string expected{"01020003000000"};
+    node::Sv2NetMsg sv2_net_msg{node::Sv2SetupConnectionSuccessMsg{2, 3}};
+
+    DataStream ss{};
+    ss << sv2_net_msg;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+BOOST_AUTO_TEST_CASE(Sv2SetupConnectionError_test)
+{
+    // 00 00 00 00     - flags
+    // 19 - error_code length
+    // 70726f746f636f6c2d76657273696f6e2d6d69736d61746368 - error_code
+    std::string expected{"000000001970726f746f636f6c2d76657273696f6e2d6d69736d61746368"};
+    node::Sv2SetupConnectionErrorMsg setup_conn_err{0, std::string{"protocol-version-mismatch"}};
+
+    DataStream ss{};
+    ss << setup_conn_err;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sv2_noise_tests.cpp
+++ b/src/test/sv2_noise_tests.cpp
@@ -1,0 +1,159 @@
+#include <common/sv2_noise.h>
+#include <key.h>
+#include <random.h>
+#include <test/util/setup_common.h>
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(sv2_noise_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(MixKey_test)
+{
+    Sv2SymmetricState i_ss;
+    Sv2SymmetricState r_ss;
+    BOOST_CHECK_EQUAL(r_ss.GetChainingKey(), i_ss.GetChainingKey());
+
+    CKey initiator_key{GenerateRandomKey()};
+    auto initiator_pk = initiator_key.EllSwiftCreate(MakeByteSpan(GetRandHash()));
+
+    CKey responder_key{GenerateRandomKey()};
+    auto responder_pk = responder_key.EllSwiftCreate(MakeByteSpan(GetRandHash()));
+
+    auto ecdh_output_1 = initiator_key.ComputeBIP324ECDHSecret(responder_pk, initiator_pk, true);
+    auto ecdh_output_2 = responder_key.ComputeBIP324ECDHSecret(initiator_pk, responder_pk, false);
+
+    BOOST_CHECK(std::memcmp(&ecdh_output_1[0], &ecdh_output_2[0], 32) == 0);
+
+    i_ss.MixKey(ecdh_output_1);
+    r_ss.MixKey(ecdh_output_2);
+
+    BOOST_CHECK_EQUAL(r_ss.GetChainingKey(), i_ss.GetChainingKey());
+}
+
+BOOST_AUTO_TEST_CASE(certificate_test)
+{
+    auto alice_static_key{GenerateRandomKey()};
+    auto alice_authority_key{GenerateRandomKey()};
+
+    // Create certificate
+    auto epoch_now = std::chrono::system_clock::now().time_since_epoch();
+    uint32_t now = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(epoch_now).count());
+    uint16_t version = 0;
+    uint32_t valid_from = now;
+    uint32_t valid_to = std::numeric_limits<unsigned int>::max();
+
+    auto alice_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
+                                                      XOnlyPubKey(alice_static_key.GetPubKey()), alice_authority_key);
+
+    BOOST_REQUIRE(alice_certificate.Validate(XOnlyPubKey(alice_authority_key.GetPubKey())));
+
+    auto malory_authority_key{GenerateRandomKey()};
+    BOOST_REQUIRE(!alice_certificate.Validate(XOnlyPubKey(malory_authority_key.GetPubKey())));
+
+    // Check that certificate is not from the future
+    valid_from = now + 10000;
+    alice_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
+                                                 XOnlyPubKey(alice_static_key.GetPubKey()), alice_authority_key);
+    BOOST_REQUIRE(!alice_certificate.Validate(XOnlyPubKey(alice_authority_key.GetPubKey())));
+
+    valid_from = now;
+
+    // Check certificate expiration
+    valid_to = now - 10000;
+    alice_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
+                                                 XOnlyPubKey(alice_static_key.GetPubKey()), alice_authority_key);
+    BOOST_REQUIRE(!alice_certificate.Validate(XOnlyPubKey(alice_authority_key.GetPubKey())));
+
+    valid_to = now;
+
+    // Only version 0 is supported
+    version = 1;
+    alice_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
+                                                 XOnlyPubKey(alice_static_key.GetPubKey()), alice_authority_key);
+    BOOST_REQUIRE(!alice_certificate.Validate(XOnlyPubKey(alice_authority_key.GetPubKey())));
+}
+
+BOOST_AUTO_TEST_CASE(handshake_and_transport_test)
+{
+    // Alice initiates a handshake with Bob
+
+    auto alice_static_key{GenerateRandomKey()};
+    auto bob_static_key{GenerateRandomKey()};
+    auto bob_authority_key{GenerateRandomKey()};
+
+    // Create certificates
+    auto epoch_now = std::chrono::system_clock::now().time_since_epoch();
+    uint16_t version = 0;
+    uint32_t valid_from = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(epoch_now).count());
+    uint32_t valid_to = std::numeric_limits<unsigned int>::max();
+
+    auto bob_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
+                                                    XOnlyPubKey(bob_static_key.GetPubKey()),
+                                                    bob_authority_key);
+
+    // Alice's static is not used in the test
+    // Alice needs to verify Bob's certificate, so we pass his authority key
+    auto alice_handshake = std::make_unique<Sv2HandshakeState>(std::move(alice_static_key),
+                                                               XOnlyPubKey(bob_authority_key.GetPubKey()));
+    // Bob is the responder and does not receive (or verify) Alice's certificate,
+    // so we don't pass her authority key.
+    auto bob_handshake = std::make_unique<Sv2HandshakeState>(std::move(bob_static_key),
+                                                             std::move(bob_certificate));
+
+    // Handshake Act 1: e ->
+
+    std::vector<std::byte> transport;
+    transport.resize(Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE);
+    // Alice generates her ephemeral public key and write it into the buffer:
+    alice_handshake->WriteMsgEphemeralPK(transport);
+    EllSwiftPubKey alice_pubkey(transport);
+
+    // Bob reads the ephemeral key
+    bob_handshake->ReadMsgEphemeralPK(transport);
+
+    ClearShrink(transport);
+
+    // Handshake Act 2: <- e, ee, s, es, SIGNATURE_NOISE_MESSAGE
+    transport.resize(Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+    bob_handshake->WriteMsgES(transport);
+    BOOST_REQUIRE(alice_handshake->ReadMsgES(transport));
+
+    // Construct Sv2Cipher from the Sv2HandshakeState and test transport
+    auto alice{Sv2Cipher(/*initiator=*/true, std::move(alice_handshake))};
+    auto bob{Sv2Cipher(/*initiator=*/false, std::move(bob_handshake))};
+    alice.FinishHandshake();
+    bob.FinishHandshake();
+
+    ClearShrink(transport);
+
+    const std::vector<uint8_t> TEST = {
+        // hello world
+        0x68,
+        0x65,
+        0x6C,
+        0x6C,
+        0x6F,
+        0x20,
+        0x77,
+        0x6F,
+        0x72,
+        0x6C,
+        0x64,
+    };
+
+    const size_t encrypted_size = Sv2Cipher::EncryptedMessageSize(TEST.size());
+    BOOST_CHECK_EQUAL(encrypted_size, TEST.size() + Poly1305::TAGLEN);
+
+    transport.resize(encrypted_size);
+
+    auto plain_send{MakeByteSpan(TEST)};
+    BOOST_TEST_CHECKPOINT("Alice encrypts message");
+    BOOST_REQUIRE(alice.EncryptMessage(plain_send, transport));
+
+    std::vector<std::byte> plain_receive(TEST.size(), std::byte(0));
+    BOOST_TEST_CHECKPOINT("Bob decrypts message");
+    BOOST_REQUIRE(bob.DecryptMessage(transport, plain_receive));
+    BOOST_CHECK_EQUAL(HexStr(plain_receive), HexStr(TEST));
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sv2_template_provider_tests.cpp
+++ b/src/test/sv2_template_provider_tests.cpp
@@ -1,0 +1,153 @@
+#include <boost/test/unit_test.hpp>
+#include <common/sv2_messages.h>
+#include <interfaces/mining.h>
+#include <node/sv2_template_provider.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+#include <util/sock.h>
+
+#include <memory>
+
+BOOST_FIXTURE_TEST_SUITE(sv2_template_provider_tests, TestChain100Setup)
+
+/**
+  * A class for testing the Template Provider. Each TPTester encapsulates a
+  * Sv2TemplateProvider (the one being tested) as well as a Sv2Cipher
+  * to act as the other side.
+  */
+class TPTester {
+private:
+    std::unique_ptr<Sv2Transport> m_peer_transport; //!< Transport for peer
+    // Sockets that will be returned by the TP listening socket Accept() method.
+    std::shared_ptr<DynSock::Queue> m_tp_accepted_sockets{std::make_shared<DynSock::Queue>()};
+    std::shared_ptr<DynSock::Pipes> m_current_client_pipes;
+
+public:
+    std::unique_ptr<Sv2TemplateProvider> m_tp; //!< Sv2TemplateProvider being tested
+    Sv2TemplateProviderOptions m_tp_options{}; //! Options passed to the TP
+
+    TPTester(interfaces::Mining& mining)
+    {
+        m_tp = std::make_unique<Sv2TemplateProvider>(mining);
+
+        CreateSock = [this](int, int, int) -> std::unique_ptr<Sock> {
+            // This will be the bind/listen socket from m_tp. It will
+            // create other sockets via its Accept() method.
+            return std::make_unique<DynSock>(std::make_shared<DynSock::Pipes>(), m_tp_accepted_sockets);
+        };
+
+        BOOST_REQUIRE(m_tp->Start(m_tp_options));
+    }
+
+    void SendPeerBytes()
+    {
+        const auto& [data, more, _m_message_type] = m_peer_transport->GetBytesToSend(/*have_next_message=*/false);
+        BOOST_REQUIRE(data.size() > 0);
+
+        // Schedule data to be returned by the next Recv() call from
+        // Sv2Connman on the socket it has accepted.
+        m_current_client_pipes->recv.PushBytes(data.data(), data.size());
+        m_peer_transport->MarkBytesSent(data.size());
+    }
+
+    // Have the peer receive and process bytes:
+    size_t PeerReceiveBytes()
+    {
+        uint8_t buf[0x10000];
+        // Get the data that has been written to the accepted socket with Send() by TP.
+        // Wait until the bytes appear in the "send" pipe.
+        ssize_t n;
+        for (;;) {
+            n = m_current_client_pipes->send.GetBytes(buf, sizeof(buf), 0);
+            if (n != -1 || errno != EAGAIN) {
+                break;
+            }
+            UninterruptibleSleep(50ms);
+        }
+
+        // Inform client's transport that some bytes have been received (sent by TP).
+        if (n > 0) {
+            Span<const uint8_t> s(buf, n);
+            BOOST_REQUIRE(m_peer_transport->ReceivedBytes(s));
+        }
+
+        return n;
+    }
+
+    /* Create a new client and perform handshake */
+    void handshake()
+    {
+        m_peer_transport.reset();
+
+        auto peer_static_key{GenerateRandomKey()};
+        m_peer_transport = std::make_unique<Sv2Transport>(std::move(peer_static_key), m_tp->m_authority_pubkey);
+
+        // Have Sv2Connman's listen socket's Accept() simulate a newly arrived connection.
+        m_current_client_pipes = std::make_shared<DynSock::Pipes>();
+        m_tp_accepted_sockets->Push(
+            std::make_unique<DynSock>(m_current_client_pipes, std::make_shared<DynSock::Queue>()));
+
+        // Flush transport for handshake part 1
+        SendPeerBytes();
+
+        // Read handshake part 2 from transport
+        BOOST_REQUIRE_EQUAL(PeerReceiveBytes(), Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+    }
+
+    void receiveMessage(Sv2NetMsg& msg)
+    {
+        // Client encrypts message and puts it on the transport:
+        CSerializedNetMsg net_msg{std::move(msg)};
+        BOOST_REQUIRE(m_peer_transport->SetMessageToSend(net_msg));
+        SendPeerBytes();
+    }
+
+    Sv2NetMsg SetupConnectionMsg()
+    {
+        std::vector<uint8_t> bytes{
+            0x02,                                                 // protocol
+            0x02, 0x00,                                           // min_version
+            0x02, 0x00,                                           // max_version
+            0x01, 0x00, 0x00, 0x00,                               // flags
+            0x07, 0x30, 0x2e, 0x30, 0x2e, 0x30, 0x2e, 0x30,       // endpoint_host
+            0x61, 0x21,                                           // endpoint_port
+            0x07, 0x42, 0x69, 0x74, 0x6d, 0x61, 0x69, 0x6e,       // vendor
+            0x08, 0x53, 0x39, 0x69, 0x20, 0x31, 0x33, 0x2e, 0x35, // hardware_version
+            0x1c, 0x62, 0x72, 0x61, 0x69, 0x69, 0x6e, 0x73, 0x2d, 0x6f, 0x73, 0x2d, 0x32, 0x30,
+            0x31, 0x38, 0x2d, 0x30, 0x39, 0x2d, 0x32, 0x32, 0x2d, 0x31, 0x2d, 0x68, 0x61, 0x73,
+            0x68, // firmware
+            0x10, 0x73, 0x6f, 0x6d, 0x65, 0x2d, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65, 0x2d, 0x75,
+            0x75, 0x69, 0x64, // device_id
+        };
+
+        return node::Sv2NetMsg{node::Sv2MsgType::SETUP_CONNECTION, std::move(bytes)};
+    }
+};
+
+BOOST_AUTO_TEST_CASE(client_tests)
+{
+    auto mining{interfaces::MakeMining(m_node)};
+    TPTester tester{*mining};
+
+    tester.handshake();
+
+    // After the handshake the client must send a SetupConnection message to the
+    // Template Provider.
+
+    tester.handshake();
+    BOOST_TEST_MESSAGE("Handshake done, send SetupConnectionMsg");
+
+    node::Sv2NetMsg setup{tester.SetupConnectionMsg()};
+    tester.receiveMessage(setup);
+    // SetupConnection.Success is 6 bytes
+    BOOST_REQUIRE_EQUAL(tester.PeerReceiveBytes(), SV2_HEADER_ENCRYPTED_SIZE + 6 + Poly1305::TAGLEN);
+
+    std::vector<uint8_t> coinbase_output_max_additional_size_bytes{
+        0x01, 0x00, 0x00, 0x00
+    };
+    node::Sv2NetMsg msg{node::Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE, std::move(coinbase_output_max_additional_size_bytes)};
+    // No reply expected, not yet implemented
+    tester.receiveMessage(msg);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sv2_transport_tests.cpp
+++ b/src/test/sv2_transport_tests.cpp
@@ -1,0 +1,388 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/sv2_noise.h>
+#include <common/sv2_transport.h>
+#include <logging.h>
+#include <serialize.h>
+#include <span.h>
+#include <streams.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <node/timeoffsets.h>
+#include <util/bitdeque.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <ios>
+#include <memory>
+#include <optional>
+#include <string>
+
+using namespace std::literals;
+using node::Sv2NetMsg;
+using node::Sv2CoinbaseOutputDataSizeMsg;
+using node::Sv2MsgType;
+
+BOOST_FIXTURE_TEST_SUITE(sv2_transport_tests, RegTestingSetup)
+
+namespace {
+
+/** A class for scenario-based tests of Sv2Transport
+ *
+ * Each Sv2TransportTester encapsulates a Sv2Transport (the one being tested),
+ * and can be told to interact with it. To do so, it also encapsulates a Sv2Cipher
+ * to act as the other side. A second Sv2Transport is not used, as doing so would
+ * not permit scenarios that involve sending invalid data.
+ */
+class Sv2TransportTester
+{
+    std::unique_ptr<Sv2Transport> m_transport; //!< Sv2Transport being tested
+    std::unique_ptr<Sv2Cipher> m_peer_cipher;  //!< Cipher to help with the other side
+    bool m_test_initiator;    //!< Whether m_transport is the initiator (true) or responder (false)
+
+    std::vector<uint8_t> m_to_send;  //!< Bytes we have queued up to send to m_transport->
+    std::vector<uint8_t> m_received; //!< Bytes we have received from m_transport->
+    std::deque<Sv2NetMsg> m_msg_to_send; //!< Messages to be sent *by* m_transport to us.
+
+public:
+    /** Construct a tester object. test_initiator: whether the tested transport is initiator. */
+
+    explicit Sv2TransportTester(bool test_initiator) : m_test_initiator(test_initiator)
+    {
+        auto initiator_static_key{GenerateRandomKey()};
+        auto responder_static_key{GenerateRandomKey()};
+        auto responder_authority_key{GenerateRandomKey()};
+
+        // Create certificates
+        auto epoch_now = std::chrono::system_clock::now().time_since_epoch();
+        uint16_t version = 0;
+        uint32_t valid_from = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(epoch_now).count());
+        uint32_t valid_to =  std::numeric_limits<unsigned int>::max();
+
+        auto responder_certificate = Sv2SignatureNoiseMessage(version, valid_from, valid_to,
+                                    XOnlyPubKey(responder_static_key.GetPubKey()), responder_authority_key);
+
+        if (test_initiator) {
+            m_transport = std::make_unique<Sv2Transport>(initiator_static_key, XOnlyPubKey(responder_authority_key.GetPubKey()));
+            m_peer_cipher = std::make_unique<Sv2Cipher>(std::move(responder_static_key), std::move(responder_certificate));
+        } else {
+            m_transport = std::make_unique<Sv2Transport>(responder_static_key, responder_certificate);
+            m_peer_cipher = std::make_unique<Sv2Cipher>(std::move(initiator_static_key), XOnlyPubKey(responder_authority_key.GetPubKey()));
+        }
+    }
+
+    /** Data type returned by Interact:
+     *
+     * - std::nullopt: transport error occurred
+     * - otherwise: a vector of
+     *   - std::nullopt: invalid message received
+     *   - otherwise: a Sv2NetMsg retrieved
+     */
+    using InteractResult = std::optional<std::vector<std::optional<Sv2NetMsg>>>;
+
+    void LogProgress(bool should_progress, bool progress, bool pretend_no_progress) {
+        if (!should_progress) {
+            BOOST_TEST_MESSAGE("[Interact] !should_progress");
+        } else if  (!progress) {
+            BOOST_TEST_MESSAGE("[Interact] should_progress && !progress");
+        } else if (pretend_no_progress) {
+            BOOST_TEST_MESSAGE("[Interact] pretend !progress");
+        }
+    }
+
+    /** Send/receive scheduled/available bytes and messages.
+     *
+     * This is the only function that interacts with the transport being tested; everything else is
+     * scheduling things done by Interact(), or processing things learned by it.
+     */
+    InteractResult Interact()
+    {
+        std::vector<std::optional<Sv2NetMsg>> ret;
+        while (true) {
+            bool progress{false};
+            // Send bytes from m_to_send to the transport.
+            if (!m_to_send.empty()) {
+                size_t n_bytes_to_send = 1 + InsecureRandRange(m_to_send.size());
+                BOOST_TEST_MESSAGE(strprintf("[Interact] send %d of %d bytes", n_bytes_to_send, m_to_send.size()));
+                Span<const uint8_t> to_send = Span{m_to_send}.first(n_bytes_to_send);
+                size_t old_len = to_send.size();
+                if (!m_transport->ReceivedBytes(to_send)) {
+                    BOOST_TEST_MESSAGE("[Interact] transport error");
+                    return std::nullopt;
+                }
+                if (old_len != to_send.size()) {
+                    progress = true;
+                    m_to_send.erase(m_to_send.begin(), m_to_send.begin() + (old_len - to_send.size()));
+                }
+            }
+            // Retrieve messages received by the transport.
+            bool should_progress = m_transport->ReceivedMessageComplete();
+            bool pretend_no_progress = InsecureRandBool();
+            LogProgress(should_progress, progress, pretend_no_progress);
+            if (should_progress && (!progress || pretend_no_progress)) {
+                bool dummy_reject_message = false;
+                CNetMessage net_msg = m_transport->GetReceivedMessage(std::chrono::microseconds(0), dummy_reject_message);
+                Sv2NetMsg msg(std::move(net_msg));
+                ret.emplace_back(std::move(msg));
+                progress = true;
+            }
+            // Enqueue a message to be sent by the transport to us.
+            should_progress = !m_msg_to_send.empty();
+            pretend_no_progress = InsecureRandBool();
+            LogProgress(should_progress, progress, pretend_no_progress);
+            if (should_progress && (!progress || pretend_no_progress)) {
+                BOOST_TEST_MESSAGE("Shoehorn into CSerializedNetMsg");
+                CSerializedNetMsg msg{m_msg_to_send.front()};
+                BOOST_TEST_MESSAGE("Call SetMessageToSend");
+                if (m_transport->SetMessageToSend(msg)) {
+                    BOOST_TEST_MESSAGE("Finished SetMessageToSend");
+                    m_msg_to_send.pop_front();
+                    progress = true;
+                }
+            }
+            // Receive bytes from the transport.
+            const auto& [recv_bytes, _more, _m_type] = m_transport->GetBytesToSend(!m_msg_to_send.empty());
+            should_progress = !recv_bytes.empty();
+            pretend_no_progress = InsecureRandBool();
+            LogProgress(should_progress, progress, pretend_no_progress);
+            if (should_progress && (!progress || pretend_no_progress)) {
+                size_t to_receive = 1 + InsecureRandRange(recv_bytes.size());
+                BOOST_TEST_MESSAGE(strprintf("[Interact] receive %d of %d bytes", to_receive, recv_bytes.size()));
+                m_received.insert(m_received.end(), recv_bytes.begin(), recv_bytes.begin() + to_receive);
+                progress = true;
+                m_transport->MarkBytesSent(to_receive);
+            }
+            if (!progress) break;
+        }
+        return ret;
+    }
+
+    /** Schedule bytes to be sent to the transport. */
+    void Send(Span<const uint8_t> data)
+    {
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Send: %s\n", HexStr(data));
+        m_to_send.insert(m_to_send.end(), data.begin(), data.end());
+    }
+
+    /** Schedule bytes to be sent to the transport. */
+    void Send(Span<const std::byte> data) { Send(MakeUCharSpan(data)); }
+
+    /** Schedule a message to be sent to us by the transport. */
+    void AddMessage(Sv2NetMsg msg)
+    {
+        m_msg_to_send.push_back(std::move(msg));
+    }
+
+    /**
+     * If we are the initiator, the send buffer should contain our ephemeral public
+     * key. Pass this to the peer cipher and clear the buffer.
+     *
+     * If we are the responder, put the peer ephemeral public key on our receive buffer.
+     */
+    void ProcessHandshake1() {
+        if (m_test_initiator) {
+            BOOST_REQUIRE(m_received.size() == Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE);
+            m_peer_cipher->GetHandshakeState().ReadMsgEphemeralPK(MakeWritableByteSpan(m_received));
+            m_received.clear();
+        } else {
+            BOOST_REQUIRE(m_to_send.empty());
+            m_to_send.resize(Sv2HandshakeState::ELLSWIFT_PUB_KEY_SIZE);
+            m_peer_cipher->GetHandshakeState().WriteMsgEphemeralPK(MakeWritableByteSpan(m_to_send));
+        }
+
+    }
+
+    /** Expect key to have been received from transport and process it.
+     *
+     * Many other Sv2TransportTester functions cannot be called until after
+     * ProcessHandshake2() has been called, as no encryption keys are set up before that point.
+     */
+    void ProcessHandshake2()
+    {
+        if (m_test_initiator) {
+            BOOST_REQUIRE(m_to_send.empty());
+
+            // Have the peer cypher write the second part of the handshake into our receive buffer
+            m_to_send.resize(Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+            m_peer_cipher->GetHandshakeState().WriteMsgES(MakeWritableByteSpan(m_to_send));
+
+            // At this point the peer is done with the handshake:
+            m_peer_cipher->FinishHandshake();
+        } else {
+            BOOST_REQUIRE(m_received.size() == Sv2HandshakeState::HANDSHAKE_STEP2_SIZE);
+            BOOST_REQUIRE(m_peer_cipher->GetHandshakeState().ReadMsgES(MakeWritableByteSpan(m_received)));
+            m_received.clear();
+
+            m_peer_cipher->FinishHandshake();
+        }
+    }
+
+    /** Schedule an encrypted packet with specified content to be sent to transport
+     *  (only after ReceiveKey). */
+    void SendPacket(Sv2NetMsg msg)
+    {
+        // TODO: randomly break stuff
+
+        std::vector<std::byte> ciphertext;
+        const size_t encrypted_payload_size = Sv2Cipher::EncryptedMessageSize(msg.size());
+        ciphertext.resize(SV2_HEADER_ENCRYPTED_SIZE + encrypted_payload_size);
+        Span<std::byte> buffer_span{MakeWritableByteSpan(ciphertext)};
+
+        // Header
+        DataStream ss_header_plain{};
+        ss_header_plain << Sv2NetHeader(msg);
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Header: %s\n", HexStr(ss_header_plain));
+        Span<std::byte> header_encrypted{buffer_span.subspan(0, SV2_HEADER_ENCRYPTED_SIZE)};
+        BOOST_REQUIRE(m_peer_cipher->EncryptMessage(ss_header_plain, header_encrypted));
+
+        // Payload
+        Span<const std::byte> payload_plain = MakeByteSpan(msg);
+        // TODO: truncate very long messages, about 100 bytes at the start and end
+        //       is probably enough for most debugging.
+        LogPrintLevel(BCLog::SV2, BCLog::Level::Trace, "Payload: %s\n", HexStr(payload_plain));
+        Span<std::byte> payload_encrypted{buffer_span.subspan(SV2_HEADER_ENCRYPTED_SIZE, encrypted_payload_size)};
+        BOOST_REQUIRE(m_peer_cipher->EncryptMessage(payload_plain, payload_encrypted));
+
+        // Schedule it for sending.
+        Send(ciphertext);
+    }
+
+    /** Expect application packet to have been received, with specified message type and payload.
+     *  (only after ReceiveKey). */
+    void ReceiveMessage(Sv2NetMsg expected_msg)
+    {
+        // When processing a packet, at least enough bytes for its length descriptor must be received.
+        BOOST_REQUIRE(m_received.size() >= SV2_HEADER_ENCRYPTED_SIZE);
+
+        auto header_encrypted{MakeWritableByteSpan(m_received).subspan(0, SV2_HEADER_ENCRYPTED_SIZE)};
+        std::array<std::byte, SV2_HEADER_PLAIN_SIZE> header_plain;
+        BOOST_REQUIRE(m_peer_cipher->DecryptMessage(header_encrypted, header_plain));
+
+        // Decode header
+        DataStream ss_header{header_plain};
+        node::Sv2NetHeader header;
+        ss_header >> header;
+
+        BOOST_CHECK(header.m_msg_type == expected_msg.m_msg_type);
+
+        size_t expanded_size = Sv2Cipher::EncryptedMessageSize(header.m_msg_len);
+        BOOST_REQUIRE(m_received.size() >= SV2_HEADER_ENCRYPTED_SIZE + expanded_size);
+
+        Span<std::byte> encrypted_payload{MakeWritableByteSpan(m_received).subspan(SV2_HEADER_ENCRYPTED_SIZE, expanded_size)};
+        Span<std::byte> payload = encrypted_payload.subspan(0, header.m_msg_len);
+
+        BOOST_REQUIRE(m_peer_cipher->DecryptMessage(encrypted_payload, payload));
+
+        std::vector<uint8_t> decode_buffer;
+        decode_buffer.resize(header.m_msg_len);
+
+        std::transform(payload.begin(), payload.end(), decode_buffer.begin(),
+                           [](std::byte b) { return static_cast<uint8_t>(b); });
+
+        // TODO: clear the m_received we used
+
+        Sv2NetMsg message{header.m_msg_type, std::move(decode_buffer)};
+
+        // TODO: compare payload
+    }
+
+    /** Test whether the transport's m_hash matches the other side. */
+    void CompareHash() const
+    {
+        BOOST_REQUIRE(m_transport);
+        BOOST_CHECK(m_transport->NoiseHash() == m_peer_cipher->GetHash());
+    }
+
+    void CheckRecvState(Sv2Transport::RecvState state) {
+        BOOST_REQUIRE(m_transport);
+        BOOST_CHECK_EQUAL(RecvStateAsString(m_transport->GetRecvState()), RecvStateAsString(state));
+    }
+
+    void CheckSendState(Sv2Transport::SendState state) {
+        BOOST_REQUIRE(m_transport);
+        BOOST_CHECK_EQUAL(SendStateAsString(m_transport->GetSendState()), SendStateAsString(state));
+    }
+
+    /** Introduce a bit error in the data scheduled to be sent. */
+    // void Damage()
+    // {
+    //     BOOST_TEST_MESSAGE("[Interact] introduce a bit error");
+    //     m_to_send[InsecureRandRange(m_to_send.size())] ^= (uint8_t{1} << InsecureRandRange(8));
+    // }
+};
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(sv2_transport_initiator_test)
+{
+    // A mostly normal scenario, testing a transport in initiator mode.
+    // Interact() introduces randomness, so run multiple times
+    for (int i = 0; i < 10; ++i) {
+        BOOST_TEST_MESSAGE(strprintf("\nIteration %d (initiator)", i));
+        Sv2TransportTester tester(true);
+        // As the initiator, our ephemeral public key is immedidately put
+        // onto the buffer.
+        tester.CheckSendState(Sv2Transport::SendState::HANDSHAKE_STEP_2);
+        tester.CheckRecvState(Sv2Transport::RecvState::HANDSHAKE_STEP_2);
+        auto ret = tester.Interact();
+        BOOST_REQUIRE(ret && ret->empty());
+        tester.ProcessHandshake1();
+        ret = tester.Interact();
+        BOOST_REQUIRE(ret && ret->empty());
+        tester.ProcessHandshake2();
+        ret = tester.Interact();
+        BOOST_REQUIRE(ret && ret->empty());
+        tester.CheckSendState(Sv2Transport::SendState::READY);
+        tester.CheckRecvState(Sv2Transport::RecvState::APP);
+        tester.CompareHash();
+    }
+}
+
+BOOST_AUTO_TEST_CASE(sv2_transport_responder_test)
+{
+    // Normal scenario, with a transport in responder node.
+    for (int i = 0; i < 10; ++i) {
+        BOOST_TEST_MESSAGE(strprintf("\nIteration %d (responder)", i));
+        Sv2TransportTester tester(false);
+        tester.CheckSendState(Sv2Transport::SendState::HANDSHAKE_STEP_2);
+        tester.CheckRecvState(Sv2Transport::RecvState::HANDSHAKE_STEP_1);
+        tester.ProcessHandshake1();
+        auto ret = tester.Interact();
+        BOOST_REQUIRE(ret && ret->empty());
+        tester.CheckSendState(Sv2Transport::SendState::READY);
+        tester.CheckRecvState(Sv2Transport::RecvState::APP);
+
+        // Have the test cypher process our handshake reply
+        tester.ProcessHandshake2();
+        tester.CompareHash();
+
+        // Handshake complete, have the initiator send us a message:
+        Sv2CoinbaseOutputDataSizeMsg body{4000};
+        Sv2NetMsg msg{body};
+        BOOST_REQUIRE(msg.m_msg_type == Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE);
+
+        tester.SendPacket(msg);
+        ret = tester.Interact();
+        BOOST_REQUIRE(ret && ret->size() == 1);
+        BOOST_CHECK((*ret)[0] &&
+                    (*ret)[0]->m_msg_type == Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE);
+
+        tester.CompareHash();
+
+        // Send a message back to the initiator
+        tester.AddMessage(msg);
+        ret = tester.Interact();
+        BOOST_REQUIRE(ret && ret->size() == 0);
+        tester.ReceiveMessage(msg);
+
+        // TODO: send / receive message larger than the chunk size
+    }
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -137,3 +137,106 @@ std::vector<NodeEvictionCandidate> GetRandomNodeEvictionCandidates(int n_candida
     }
     return candidates;
 }
+
+// Have different ZeroSock (or others that inherit from it) objects have different
+// m_socket because EqualSharedPtrSock compares m_socket and we want to avoid two
+// different objects comparing as equal.
+static std::atomic<SOCKET> g_mocked_sock_fd{0};
+
+ZeroSock::ZeroSock() : Sock{g_mocked_sock_fd++} {}
+
+// Sock::~Sock() would try to close(2) m_socket if it is not INVALID_SOCKET, avoid that.
+ZeroSock::~ZeroSock() { m_socket = INVALID_SOCKET; }
+
+ssize_t ZeroSock::Send(const void*, size_t len, int) const { return len; }
+
+ssize_t ZeroSock::Recv(void* buf, size_t len, int flags) const
+{
+    memset(buf, 0x0, len);
+    return len;
+}
+
+int ZeroSock::Connect(const sockaddr*, socklen_t) const { return 0; }
+
+int ZeroSock::Bind(const sockaddr*, socklen_t) const { return 0; }
+
+int ZeroSock::Listen(int) const { return 0; }
+
+std::unique_ptr<Sock> ZeroSock::Accept(sockaddr* addr, socklen_t* addr_len) const
+{
+    if (addr != nullptr) {
+        // Pretend all connections come from 5.5.5.5:6789
+        memset(addr, 0x00, *addr_len);
+        const socklen_t write_len = static_cast<socklen_t>(sizeof(sockaddr_in));
+        if (*addr_len >= write_len) {
+            *addr_len = write_len;
+            sockaddr_in* addr_in = reinterpret_cast<sockaddr_in*>(addr);
+            addr_in->sin_family = AF_INET;
+            memset(&addr_in->sin_addr, 0x05, sizeof(addr_in->sin_addr));
+            addr_in->sin_port = htons(6789);
+        }
+    }
+    return std::make_unique<ZeroSock>();
+}
+
+int ZeroSock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
+{
+    std::memset(opt_val, 0x0, *opt_len);
+    return 0;
+}
+
+int ZeroSock::SetSockOpt(int, int, const void*, socklen_t) const { return 0; }
+
+int ZeroSock::GetSockName(sockaddr* name, socklen_t* name_len) const
+{
+    std::memset(name, 0x0, *name_len);
+    return 0;
+}
+
+bool ZeroSock::SetNonBlocking() const { return true; }
+
+bool ZeroSock::IsSelectable() const { return true; }
+
+bool ZeroSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
+{
+    if (occurred != nullptr) {
+        *occurred = requested;
+    }
+    return true;
+}
+
+bool ZeroSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock) const
+{
+    for (auto& [sock, events] : events_per_sock) {
+        (void)sock;
+        events.occurred = events.requested;
+    }
+    return true;
+}
+
+ZeroSock& ZeroSock::operator=(Sock&& other)
+{
+    assert(false && "Move of Sock into ZeroSock not allowed.");
+    return *this;
+}
+
+StaticContentsSock::StaticContentsSock(const std::string& contents)
+    : m_contents{contents}
+{
+}
+
+ssize_t StaticContentsSock::Recv(void* buf, size_t len, int flags) const
+{
+    const size_t consume_bytes{std::min(len, m_contents.size() - m_consumed)};
+    std::memcpy(buf, m_contents.data() + m_consumed, consume_bytes);
+    if ((flags & MSG_PEEK) == 0) {
+        m_consumed += consume_bytes;
+    }
+    return consume_bytes;
+}
+
+StaticContentsSock& StaticContentsSock::operator=(Sock&& other)
+{
+    assert(false && "Move of Sock into StaticContentsSock not allowed.");
+    return *this;
+}

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -14,7 +14,10 @@
 #include <random.h>
 #include <serialize.h>
 #include <span.h>
+#include <sync.h>
 
+#include <chrono>
+#include <optional>
 #include <vector>
 
 void ConnmanTestMsg::Handshake(CNode& node,
@@ -238,5 +241,169 @@ ssize_t StaticContentsSock::Recv(void* buf, size_t len, int flags) const
 StaticContentsSock& StaticContentsSock::operator=(Sock&& other)
 {
     assert(false && "Move of Sock into StaticContentsSock not allowed.");
+    return *this;
+}
+
+ssize_t DynSock::Pipe::GetBytes(void* buf, size_t len, int flags)
+{
+    WAIT_LOCK(m_mutex, lock);
+
+    if (m_data.empty()) {
+        if (m_eof) {
+            return 0;
+        }
+        errno = EAGAIN; // Same as recv(2) on a non-blocking socket.
+        return -1;
+    }
+
+    const size_t read_bytes{std::min(len, m_data.size())};
+
+    std::memcpy(buf, m_data.data(), read_bytes);
+    if ((flags & MSG_PEEK) == 0) {
+        m_data.erase(m_data.begin(), m_data.begin() + read_bytes);
+    }
+
+    return read_bytes;
+}
+
+std::optional<CNetMessage> DynSock::Pipe::GetNetMsg()
+{
+    V1Transport transport{NodeId{0}};
+
+    {
+        WAIT_LOCK(m_mutex, lock);
+
+        WaitForDataOrEof(lock);
+        if (m_eof && m_data.empty()) {
+            return std::nullopt;
+        }
+
+        for (;;) {
+            Span<const uint8_t> s{m_data};
+            if (!transport.ReceivedBytes(s)) {  // Consumed bytes are removed from the front of s.
+                return std::nullopt;
+            }
+            m_data.erase(m_data.begin(), m_data.begin() + m_data.size() - s.size());
+            if (transport.ReceivedMessageComplete()) {
+                break;
+            }
+            if (m_data.empty()) {
+                WaitForDataOrEof(lock);
+                if (m_eof && m_data.empty()) {
+                    return std::nullopt;
+                }
+            }
+        }
+    }
+
+    bool reject{false};
+    CNetMessage msg{transport.GetReceivedMessage(/*time=*/{}, reject)};
+    if (reject) {
+        return std::nullopt;
+    }
+    return std::make_optional<CNetMessage>(std::move(msg));
+}
+
+void DynSock::Pipe::PushBytes(const void* buf, size_t len)
+{
+    LOCK(m_mutex);
+    const uint8_t* b = static_cast<const uint8_t*>(buf);
+    m_data.insert(m_data.end(), b, b + len);
+    m_cond.notify_all();
+}
+
+void DynSock::Pipe::Eof()
+{
+    LOCK(m_mutex);
+    m_eof = true;
+    m_cond.notify_all();
+}
+
+void DynSock::Pipe::WaitForDataOrEof(UniqueLock<Mutex>& lock)
+{
+    Assert(lock.mutex() == &m_mutex);
+
+    m_cond.wait(lock, [&]() EXCLUSIVE_LOCKS_REQUIRED(m_mutex) {
+        AssertLockHeld(m_mutex);
+        return !m_data.empty() || m_eof;
+    });
+}
+
+DynSock::DynSock(std::shared_ptr<Pipes> pipes, std::shared_ptr<Queue> accept_sockets)
+    : m_pipes{pipes}, m_accept_sockets{accept_sockets}
+{
+}
+
+DynSock::~DynSock()
+{
+    m_pipes->send.Eof();
+}
+
+ssize_t DynSock::Recv(void* buf, size_t len, int flags) const
+{
+    return m_pipes->recv.GetBytes(buf, len, flags);
+}
+
+ssize_t DynSock::Send(const void* buf, size_t len, int) const
+{
+    m_pipes->send.PushBytes(buf, len);
+    return len;
+}
+
+std::unique_ptr<Sock> DynSock::Accept(sockaddr* addr, socklen_t* addr_len) const
+{
+    return m_accept_sockets->Pop().value_or(nullptr);
+}
+
+bool DynSock::Wait(std::chrono::milliseconds timeout,
+                   Event requested,
+                   Event* occurred) const
+{
+    EventsPerSock ev;
+    ev.emplace(this, Events{requested});
+    const bool ret{WaitMany(timeout, ev)};
+    if (occurred != nullptr) {
+        *occurred = ev.begin()->second.occurred;
+    }
+    return ret;
+}
+
+bool DynSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock) const
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    bool at_least_one_event_occurred{false};
+
+    for (;;) {
+        // Check all sockets for readiness without waiting.
+        for (auto& [sock, events] : events_per_sock) {
+            if ((events.requested & Sock::SEND) != 0) {
+                // Always ready for Send().
+                events.occurred |= Sock::SEND;
+                at_least_one_event_occurred = true;
+            }
+
+            if ((events.requested & Sock::RECV) != 0) {
+                auto dyn_sock = reinterpret_cast<const DynSock*>(sock.get());
+                uint8_t b;
+                if (dyn_sock->m_pipes->recv.GetBytes(&b, 1, MSG_PEEK) == 1 || !dyn_sock->m_accept_sockets->Empty()) {
+                    events.occurred |= Sock::RECV;
+                    at_least_one_event_occurred = true;
+                }
+            }
+        }
+
+        if (at_least_one_event_occurred || std::chrono::steady_clock::now() > deadline) {
+            break;
+        }
+
+        std::this_thread::sleep_for(10ms);
+    }
+
+    return true;
+}
+
+DynSock& DynSock::operator=(Sock&&)
+{
+    assert(false && "Move of Sock into DynSock not allowed.");
     return *this;
 }

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -6,6 +6,7 @@
 #define BITCOIN_TEST_UTIL_NET_H
 
 #include <compat/compat.h>
+#include <netmessagemaker.h>
 #include <net.h>
 #include <net_permissions.h>
 #include <net_processing.h>
@@ -19,9 +20,11 @@
 #include <array>
 #include <cassert>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -200,5 +203,156 @@ private:
     const std::string m_contents;
     mutable size_t m_consumed{0};
 };
+
+/**
+ * A mocked Sock alternative that allows providing the data to be returned by Recv()
+ * and inspecting the data that has been supplied to Send().
+ */
+class DynSock : public ZeroSock
+{
+public:
+    /**
+     * Unidirectional bytes or CNetMessage queue (FIFO).
+     */
+    class Pipe
+    {
+    public:
+        /**
+         * Get bytes and remove them from the pipe.
+         * @param[in] buf Destination to write bytes to.
+         * @param[in] len Write up to this number of bytes.
+         * @param[in] flags Same as the flags of `recv(2)`. Just `MSG_PEEK` is honored.
+         * @return The number of bytes written to `buf`. `0` if `Eof()` has been called.
+         * If no bytes are available then `-1` is returned and `errno` is set to `EAGAIN`.
+         */
+        ssize_t GetBytes(void* buf, size_t len, int flags = 0) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+        /**
+         * Deserialize a `CNetMessage` and remove it from the pipe.
+         * If not enough bytes are available then the function will wait. If parsing fails
+         * or EOF is signaled to the pipe, then `std::nullopt` is returned.
+         */
+        std::optional<CNetMessage> GetNetMsg() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+        /**
+         * Push bytes to the pipe.
+         */
+        void PushBytes(const void* buf, size_t len) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+        /**
+         * Construct and push CNetMessage to the pipe.
+         */
+        template <typename... Args>
+        void PushNetMsg(const std::string& type, Args&&... payload) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+        /**
+         * Signal end-of-file on the receiving end (`GetBytes()` or `GetNetMsg()`).
+         */
+        void Eof() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    private:
+        /**
+         * Return when there is some data to read or EOF has been signaled.
+         * @param[in,out] lock Unique lock that must have been derived from `m_mutex` by `WAIT_LOCK(m_mutex, lock)`.
+         */
+        void WaitForDataOrEof(UniqueLock<Mutex>& lock) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
+
+        Mutex m_mutex;
+        std::condition_variable m_cond;
+        std::vector<uint8_t> m_data GUARDED_BY(m_mutex);
+        bool m_eof GUARDED_BY(m_mutex){false};
+    };
+
+    struct Pipes {
+        Pipe recv;
+        Pipe send;
+    };
+
+    /**
+     * A basic thread-safe queue, used for queuing sockets to be returned by Accept().
+     */
+    class Queue
+    {
+    public:
+        using S = std::unique_ptr<DynSock>;
+
+        void Push(S s) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+        {
+            LOCK(m_mutex);
+            m_queue.push(std::move(s));
+        }
+
+        std::optional<S> Pop() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+        {
+            LOCK(m_mutex);
+            if (m_queue.empty()) {
+                return std::nullopt;
+            }
+            S front{std::move(m_queue.front())};
+            m_queue.pop();
+            return front;
+        }
+
+        bool Empty() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+        {
+            LOCK(m_mutex);
+            return m_queue.empty();
+        }
+
+    private:
+        mutable Mutex m_mutex;
+        std::queue<S> m_queue GUARDED_BY(m_mutex);
+    };
+
+    /**
+     * Create a new mocked sock.
+     * @param[in] pipes Send/recv pipes used by the Send() and Recv() methods.
+     * @param[in] accept_sockets Sockets to return by the Accept() method.
+     */
+    explicit DynSock(std::shared_ptr<Pipes> pipes, std::shared_ptr<Queue> accept_sockets);
+
+    ~DynSock();
+
+    ssize_t Recv(void* buf, size_t len, int flags) const override;
+
+    ssize_t Send(const void* buf, size_t len, int) const override;
+
+    std::unique_ptr<Sock> Accept(sockaddr* addr, socklen_t* addr_len) const override;
+
+    bool Wait(std::chrono::milliseconds timeout,
+              Event requested,
+              Event* occurred = nullptr) const override;
+
+    bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock) const override;
+
+private:
+    DynSock& operator=(Sock&&) override;
+
+    std::shared_ptr<Pipes> m_pipes;
+    std::shared_ptr<Queue> m_accept_sockets;
+};
+
+template <typename... Args>
+void DynSock::Pipe::PushNetMsg(const std::string& type, Args&&... payload)
+{
+    auto msg = NetMsg::Make(type, std::forward<Args>(payload)...);
+    V1Transport transport{NodeId{0}};
+
+    const bool queued{transport.SetMessageToSend(msg)};
+    assert(queued);
+
+    LOCK(m_mutex);
+
+    for (;;) {
+        const auto& [bytes, _more, _msg_type] = transport.GetBytesToSend(/*have_next_message=*/true);
+        if (bytes.empty()) {
+            break;
+        }
+        m_data.insert(m_data.end(), bytes.begin(), bytes.end());
+        transport.MarkBytesSent(bytes.size());
+    }
+
+    m_cond.notify_all();
+}
 
 #endif // BITCOIN_TEST_UTIL_NET_H

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
 
     // check that any deployment on any chain can conceivably reach both
     // ACTIVE and FAILED states in roughly the way we expect
-    for (const auto& chain_type: {ChainType::MAIN, ChainType::TESTNET, ChainType::SIGNET, ChainType::REGTEST}) {
+    for (const auto& chain_type: {ChainType::MAIN, ChainType::TESTNET, ChainType::TESTNET4, ChainType::SIGNET, ChainType::REGTEST}) {
         const auto chainParams = CreateChainParams(*m_node.args, chain_type);
         uint32_t chain_all_vbits{0};
         for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++i) {

--- a/src/util/chaintype.cpp
+++ b/src/util/chaintype.cpp
@@ -15,6 +15,8 @@ std::string ChainTypeToString(ChainType chain)
         return "main";
     case ChainType::TESTNET:
         return "test";
+    case ChainType::TESTNET4:
+        return "testnet4";
     case ChainType::SIGNET:
         return "signet";
     case ChainType::REGTEST:
@@ -29,6 +31,8 @@ std::optional<ChainType> ChainTypeFromString(std::string_view chain)
         return ChainType::MAIN;
     } else if (chain == "test") {
         return ChainType::TESTNET;
+    } else if (chain == "testnet4") {
+        return ChainType::TESTNET4;
     } else if (chain == "signet") {
         return ChainType::SIGNET;
     } else if (chain == "regtest") {

--- a/src/util/chaintype.h
+++ b/src/util/chaintype.h
@@ -13,6 +13,7 @@ enum class ChainType {
     TESTNET,
     SIGNET,
     REGTEST,
+    TESTNET4,
 };
 
 std::string ChainTypeToString(ChainType chain);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4170,6 +4170,18 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-too-old", "block's timestamp is too early");
 
+    // Testnet4 only: Check timestamp against prev for difficulty-adjustment
+    // blocks to prevent timewarp attacks (see https://github.com/bitcoin/bitcoin/pull/15482).
+    if (consensusParams.hashGenesisBlock == uint256S("0x00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043")) {
+        // Check timestamp for the first block of each difficulty adjustment
+        // interval, except the genesis block.
+        if (pindexPrev->nHeight % consensusParams.DifficultyAdjustmentInterval() == consensusParams.DifficultyAdjustmentInterval() - 1) {
+            if (block.GetBlockTime() < pindexPrev->GetBlockTime() - 60 * 60 * 2) {
+                return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-timewarp-attack", "block's timestamp is too early on diff adjustment block");
+            }
+        }
+    }
+
     // Check timestamp
     if (block.Time() > NodeClock::now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -371,10 +371,43 @@ class ConfArgsTest(BitcoinTestFramework):
     def test_acceptstalefeeestimates_arg_support(self):
         self.log.info("Test -acceptstalefeeestimates option support")
         conf_file = self.nodes[0].datadir_path / "bitcoin.conf"
-        for chain, chain_name in {("main", ""), ("test", "testnet3"), ("signet", "signet")}:
+        for chain, chain_name in {("main", ""), ("test", "testnet3"), ("signet", "signet"), ("testnet4", "testnet4")}:
             util.write_config(conf_file, n=0, chain=chain_name, extra_config='acceptstalefeeestimates=1\n')
             self.nodes[0].assert_start_raises_init_error(expected_msg=f'Error: acceptstalefeeestimates is not supported on {chain} chain.')
         util.write_config(conf_file, n=0, chain="regtest")  # Reset to regtest
+
+    def test_testnet3_deprecation_msg(self):
+        self.log.info("Test testnet3 deprecation warning")
+        t3_warning_log = "Warning: Support for testnet3 is deprecated and will be removed in an upcoming release. Consider switching to testnet4."
+
+        def warning_msg(node, approx_size):
+            return f'Warning: Disk space for "{node.datadir_path / node.chain / "blocks" }" may not accommodate the block files. Approximately {approx_size} GB of data will be stored in this directory.'
+
+        # Testnet3 node will log the warning
+        self.nodes[0].chain = 'testnet3'
+        self.nodes[0].replace_in_config([('regtest=', 'testnet='), ('[regtest]', '[test]')])
+        with self.nodes[0].assert_debug_log([t3_warning_log]):
+            self.start_node(0)
+        # Some CI environments will have limited space and some others won't
+        # so we need to handle both cases as a valid result.
+        self.nodes[0].stderr.seek(0)
+        err = self.nodes[0].stdout.read()
+        self.nodes[0].stderr.seek(0)
+        self.nodes[0].stderr.truncate()
+        if err != b'' and err != warning_msg(self.nodes[0], 42):
+            raise AssertionError("Unexpected stderr after shutdown of Testnet3 node")
+        self.stop_node(0)
+
+        # Testnet4 node will not log the warning
+        self.nodes[0].chain = 'testnet4'
+        self.nodes[0].replace_in_config([('testnet=', 'testnet4='), ('[test]', '[testnet4]')])
+        with self.nodes[0].assert_debug_log([], unexpected_msgs=[t3_warning_log]):
+            self.start_node(0)
+        self.stop_node(0)
+
+        # Reset to regtest
+        self.nodes[0].chain = 'regtest'
+        self.nodes[0].replace_in_config([('testnet4=', 'regtest='), ('[testnet4]', '[regtest]')])
 
     def run_test(self):
         self.test_log_buffer()
@@ -389,6 +422,7 @@ class ConfArgsTest(BitcoinTestFramework):
         self.test_ignored_conf()
         self.test_ignored_default_conf()
         self.test_acceptstalefeeestimates_arg_support()
+        self.test_testnet3_deprecation_msg()
 
         # Remove the -datadir argument so it doesn't override the config file
         self.nodes[0].args = [arg for arg in self.nodes[0].args if not arg.startswith("-datadir")]

--- a/test/functional/p2p_dos_header_tree.py
+++ b/test/functional/p2p_dos_header_tree.py
@@ -20,6 +20,7 @@ import os
 class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
+        # TODO: Update to testnet4 when a checkpoint is available
         self.chain = 'testnet3'  # Use testnet chain because it has an early checkpoint
         self.num_nodes = 2
         self.extra_args = [["-minimumchainwork=0x0", '-prune=550']] * self.num_nodes

--- a/test/functional/wallet_crosschain.py
+++ b/test/functional/wallet_crosschain.py
@@ -11,7 +11,7 @@ class WalletCrossChain(BitcoinTestFramework):
         self.add_wallet_options(parser)
 
     def set_test_params(self):
-        self.num_nodes = 2
+        self.num_nodes = 3
         self.setup_clean_chain = True
 
     def skip_test_if_missing_module(self):
@@ -24,6 +24,12 @@ class WalletCrossChain(BitcoinTestFramework):
         self.nodes[1].chain = 'testnet3'
         self.nodes[1].extra_args = ['-maxconnections=0', '-prune=550'] # disable testnet sync
         self.nodes[1].replace_in_config([('regtest=', 'testnet='), ('[regtest]', '[test]')])
+
+        # Switch node 1 to testnet4 before starting it.
+        self.nodes[2].chain = 'testnet4'
+        self.nodes[2].extra_args = ['-maxconnections=0', '-prune=550'] # disable testnet4 sync
+        self.nodes[2].replace_in_config([('regtest=', 'testnet4='), ('[regtest]', '[testnet4]')])
+
         self.start_nodes()
 
     def run_test(self):
@@ -39,19 +45,32 @@ class WalletCrossChain(BitcoinTestFramework):
         self.nodes[1].createwallet(node1_wallet)
         self.nodes[1].backupwallet(node1_wallet_backup)
         self.nodes[1].unloadwallet(node1_wallet)
+        node2_wallet = self.nodes[2].datadir_path / 'node2_wallet'
+        node2_wallet_backup = self.nodes[0].datadir_path / 'node1_wallet.bak'
+        self.nodes[2].createwallet(node2_wallet)
+        self.nodes[2].backupwallet(node2_wallet_backup)
+        self.nodes[2].unloadwallet(node2_wallet)
 
         self.log.info("Loading/restoring wallets into nodes with a different genesis block")
 
         if self.options.descriptors:
             assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[0].loadwallet, node1_wallet)
+            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[0].loadwallet, node2_wallet)
             assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[1].loadwallet, node0_wallet)
+            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[2].loadwallet, node0_wallet)
             assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[0].restorewallet, 'w', node1_wallet_backup)
+            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[0].restorewallet, 'w', node2_wallet_backup)
             assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[1].restorewallet, 'w', node0_wallet_backup)
+            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[2].restorewallet, 'w', node0_wallet_backup)
         else:
             assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[0].loadwallet, node1_wallet)
+            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[0].loadwallet, node2_wallet)
             assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[1].loadwallet, node0_wallet)
+            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[2].loadwallet, node0_wallet)
             assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[0].restorewallet, 'w', node1_wallet_backup)
+            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[0].restorewallet, 'w', node2_wallet_backup)
             assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[1].restorewallet, 'w', node0_wallet_backup)
+            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[2].restorewallet, 'w', node0_wallet_backup)
 
         if not self.options.descriptors:
             self.log.info("Override cross-chain wallet load protection")


### PR DESCRIPTION
After reading @0xB10C's [blog post](https://b10c.me/blog/014-mining-pool-game-theory-during-forks/) on mining pool behaviour during forks, I felt motivated to implement Stratum v2's future block template functionality.

Well, this is just a very rough sketch which doesn't compile.

There's two relevant protocol messages (for the Template Provider in https://github.com/bitcoin/bitcoin/pull/29432):

1. [NewTemplate](https://github.com/stratum-mining/sv2-spec/blob/main/07-Template-Distribution-Protocol.md#72-newtemplate-server---client)
2. [SetNewPrevHash](https://github.com/stratum-mining/sv2-spec/blob/main/07-Template-Distribution-Protocol.md#73-setnewprevhash-server---client)

Whenever the tip updates, the current working implementation first sends a `NewTemplate` message with `future_template` set to `true`, immediately followed by `SetNewPrevHash` for the new tip.

This PR tries to improve upon that for two different scenarios:

1. We didn't win the last block
2. We did win the last block

So prepare for either out, after we've send out the current work as described above, we send two additional templates. Both have `future_template = true` and both build for the block on top of the last template. The first is empty, the second has all the transactions that didn't fit in the original block.

Especially this last bit will require an overhaul of `BlockAssembler::CreateNewBlock`, but it would be a nice selling point for stratum v2.

So now the following things can happen:

1. We receive a block via p2p, this means we didn't* win. The Template Provider needs to look though the template cache and send the connected client(s) a `SetNewPrevHash` message referring to the match.

2. We receive a block via `SubmitSolution`. That means we found the block. The message handling code already finds the matching template. All we need to do is reply to the client with a `NewPrevHash` message.

For both (1) and (2) we then proceed as normal, creating and sending a template with non-empty block.

`* = ` actually it's possible that the Job Declarator server reconstructed the block and broadcast it for us, so I need to add detection for this case (maybe by comparing the coinbase merkle path).