### PR TITLE
ipc: breaking but non-urgent changes

### DIFF
--- a/doc/release-notes-33819.md
+++ b/doc/release-notes-33819.md
@@ -1,0 +1,6 @@
+Mining IPC
+----------
+
+- Adds `getCoinbase()` which clients should use instead of `getCoinbaseTx()`. It
+  contains all fields required to construct a coinbase transaction, and omits the
+  dummy output which Bitcoin Core uses internally. (#33819)

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -44,25 +44,16 @@ public:
 
     /** Return fields needed to construct a coinbase transaction */
     virtual node::CoinbaseTemplate getCoinbase() = 0;
-    /**
-     * Return dummy coinbase transaction.
-     *
-     * @note deprecated: use getCoinbase()
-     **/
-    virtual CTransactionRef getCoinbaseTx() = 0;
-    /**
-     * Return scriptPubKey with SegWit OP_RETURN.
-     *
-     * @note deprecated: use the required_outputs field from getCoinbase()
-     */
-    virtual std::vector<unsigned char> getCoinbaseCommitment() = 0;
-    /**
-     * Return which output in the dummy coinbase contains the SegWit OP_RETURN.
-     *
-     * @note deprecated. Scan outputs from getCoinbase() outputs field for the
-     *       SegWit marker.
-     */
-    virtual int getWitnessCommitmentIndex() = 0;
+
+    virtual void getCoinbaseTx() {
+        throw std::runtime_error("Old mining interface (@5) not supported. Please update your client!");
+    }
+    virtual void getCoinbaseCommitment() {
+        throw std::runtime_error("Old mining interface (@6) not supported. Please update your client!");
+    };
+    virtual void getWitnessCommitmentIndex() {
+        throw std::runtime_error("Old mining interface (@7) not supported. Please update your client!");
+    }
 
     /**
      * Compute merkle path to the coinbase transaction

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -52,6 +52,8 @@ public:
     virtual CTransactionRef getCoinbaseTx() = 0;
     /**
      * Return scriptPubKey with SegWit OP_RETURN.
+     *
+     * @note deprecated: use the required_outputs field from getCoinbase()
      */
     virtual std::vector<unsigned char> getCoinbaseCommitment() = 0;
     /**

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -42,8 +42,24 @@ public:
     // Sigop cost per transaction, not including coinbase transaction.
     virtual std::vector<int64_t> getTxSigops() = 0;
 
+    /** Return fields needed to construct a coinbase transaction */
+    virtual node::CoinbaseTemplate getCoinbase() = 0;
+    /**
+     * Return dummy coinbase transaction.
+     *
+     * @note deprecated: use getCoinbase()
+     **/
     virtual CTransactionRef getCoinbaseTx() = 0;
+    /**
+     * Return scriptPubKey with SegWit OP_RETURN.
+     */
     virtual std::vector<unsigned char> getCoinbaseCommitment() = 0;
+    /**
+     * Return which output in the dummy coinbase contains the SegWit OP_RETURN.
+     *
+     * @note deprecated. Scan outputs from getCoinbase() outputs field for the
+     *       SegWit marker.
+     */
     virtual int getWitnessCommitmentIndex() = 0;
 
     /**

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -17,8 +17,8 @@ interface Mining $Proxy.wrap("interfaces::Mining") {
     isInitialBlockDownload @1 (context :Proxy.Context) -> (result: Bool);
     getTip @2 (context :Proxy.Context) -> (result: Common.BlockRef, hasResult: Bool);
     waitTipChanged @3 (context :Proxy.Context, currentTip: Data, timeout: Float64) -> (result: Common.BlockRef);
-    createNewBlock @4 (options: BlockCreateOptions) -> (result: BlockTemplate);
-    checkBlock @5 (block: Data, options: BlockCheckOptions) -> (reason: Text, debug: Text, result: Bool);
+    createNewBlock @4 (context :Proxy.Context, options: BlockCreateOptions) -> (result: BlockTemplate);
+    checkBlock @5 (context :Proxy.Context, block: Data, options: BlockCheckOptions) -> (reason: Text, debug: Text, result: Bool);
 }
 
 interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -44,6 +44,7 @@ struct BlockCreateOptions $Proxy.wrap("node::BlockCreateOptions") {
     useMempool @0 :Bool $Proxy.name("use_mempool");
     blockReservedWeight @1 :UInt64 $Proxy.name("block_reserved_weight");
     coinbaseOutputMaxAdditionalSigops @2 :UInt64 $Proxy.name("coinbase_output_max_additional_sigops");
+    alwaysAddCoinbaseCommitment @3 :Bool $Proxy.name("always_add_coinbase_commitment");
 }
 
 struct BlockWaitOptions $Proxy.wrap("node::BlockWaitOptions") {

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -27,6 +27,7 @@ interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {
     getBlock @2 (context: Proxy.Context) -> (result: Data);
     getTxFees @3 (context: Proxy.Context) -> (result: List(Int64));
     getTxSigops @4 (context: Proxy.Context) -> (result: List(Int64));
+    getCoinbase @12 (context: Proxy.Context) -> (result: CoinbaseTemplate);
     getCoinbaseTx @5 (context: Proxy.Context) -> (result: Data);
     getCoinbaseCommitment @6 (context: Proxy.Context) -> (result: Data);
     getWitnessCommitmentIndex @7 (context: Proxy.Context) -> (result: Int32);
@@ -50,4 +51,14 @@ struct BlockWaitOptions $Proxy.wrap("node::BlockWaitOptions") {
 struct BlockCheckOptions $Proxy.wrap("node::BlockCheckOptions") {
     checkMerkleRoot @0 :Bool $Proxy.name("check_merkle_root");
     checkPow @1 :Bool $Proxy.name("check_pow");
+}
+
+struct CoinbaseTemplate $Proxy.wrap("node::CoinbaseTemplate") {
+    version @0 :UInt32 $Proxy.name("version");
+    sequence @1 :UInt32 $Proxy.name("sequence");
+    scriptSigPrefix @2 :Data $Proxy.name("script_sig_prefix");
+    witness @3 :Data $Proxy.name("witness");
+    valueRemaining @4 :Int64 $Proxy.name("value_remaining");
+    requiredOutputs @5 :List(Data) $Proxy.name("required_outputs");
+    lockTime @6 :UInt32 $Proxy.name("lock_time");
 }

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -28,9 +28,12 @@ interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {
     getTxFees @3 (context: Proxy.Context) -> (result: List(Int64));
     getTxSigops @4 (context: Proxy.Context) -> (result: List(Int64));
     getCoinbase @12 (context: Proxy.Context) -> (result: CoinbaseTemplate);
-    getCoinbaseTx @5 (context: Proxy.Context) -> (result: Data);
-    getCoinbaseCommitment @6 (context: Proxy.Context) -> (result: Data);
-    getWitnessCommitmentIndex @7 (context: Proxy.Context) -> (result: Int32);
+
+    # DEPRECATED in favor of getCoinbase(), server returns an error:
+    getCoinbaseTx @5 () -> ();
+    getCoinbaseCommitment @6 () -> ();
+    getWitnessCommitmentIndex @7 () -> ();
+
     getCoinbaseMerklePath @8 (context: Proxy.Context) -> (result: List(Data));
     submitSolution @9 (context: Proxy.Context, version: UInt32, timestamp: UInt32, nonce: UInt32, coinbase :Data) -> (result: Bool);
     waitNext @10 (context: Proxy.Context, options: BlockWaitOptions) -> (result: BlockTemplate);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -83,6 +83,7 @@ using interfaces::Node;
 using interfaces::WalletLoader;
 using node::BlockAssembler;
 using node::BlockWaitOptions;
+using node::CoinbaseTemplate;
 using util::Join;
 
 namespace node {
@@ -863,6 +864,7 @@ public:
     explicit BlockTemplateImpl(BlockAssembler::Options assemble_options,
                                std::unique_ptr<CBlockTemplate> block_template,
                                NodeContext& node) : m_assemble_options(std::move(assemble_options)),
+                                                    m_coinbase_template(ExtractCoinbaseTemplate(*Assert(block_template))),
                                                     m_block_template(std::move(block_template)),
                                                     m_node(node)
     {
@@ -887,6 +889,11 @@ public:
     std::vector<int64_t> getTxSigops() override
     {
         return m_block_template->vTxSigOpsCost;
+    }
+
+    CoinbaseTemplate getCoinbase() override
+    {
+        return m_coinbase_template;
     }
 
     CTransactionRef getCoinbaseTx() override
@@ -928,6 +935,8 @@ public:
     }
 
     const BlockAssembler::Options m_assemble_options;
+
+    const CoinbaseTemplate m_coinbase_template;
 
     const std::unique_ptr<CBlockTemplate> m_block_template;
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -903,6 +903,7 @@ public:
 
     std::vector<unsigned char> getCoinbaseCommitment() override
     {
+        Assume(m_coinbase_template.default_witness_commitment == m_block_template->vchCoinbaseCommitment);
         return m_block_template->vchCoinbaseCommitment;
     }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -869,6 +869,12 @@ public:
                                                     m_node(node)
     {
         assert(m_block_template);
+
+        if (m_assemble_options.clear_coinbase) {
+            // Clear dummy coinbase so it's not exposed to callers of getBlock()
+            CMutableTransaction empty_tx;
+            m_block_template->block.vtx[0] = MakeTransactionRef(std::move(empty_tx));
+        }
     }
 
     CBlockHeader getBlockHeader() override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -896,22 +896,6 @@ public:
         return m_coinbase_template;
     }
 
-    CTransactionRef getCoinbaseTx() override
-    {
-        return m_block_template->block.vtx[0];
-    }
-
-    std::vector<unsigned char> getCoinbaseCommitment() override
-    {
-        Assume(m_coinbase_template.default_witness_commitment == m_block_template->vchCoinbaseCommitment);
-        return m_block_template->vchCoinbaseCommitment;
-    }
-
-    int getWitnessCommitmentIndex() override
-    {
-        return GetWitnessCommitmentIndex(m_block_template->block);
-    }
-
     std::vector<uint256> getCoinbaseMerklePath() override
     {
         return TransactionMerklePath(m_block_template->block, 0);

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -634,6 +634,8 @@ node::CoinbaseTemplate ExtractCoinbaseTemplate(const node::CBlockTemplate& block
 
     coinbase.lock_time = coinbase_tx->nLockTime;
 
+    coinbase.default_witness_commitment = block_template.vchCoinbaseCommitment;
+
     return coinbase;
 }
 } // namespace node

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -169,7 +169,12 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     Assert(nHeight > 0);
     coinbaseTx.nLockTime = static_cast<uint32_t>(nHeight - 1);
     pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
-    pblocktemplate->vchCoinbaseCommitment = m_chainstate.m_chainman.GenerateCoinbaseCommitment(*pblock, pindexPrev);
+    if (m_options.always_add_coinbase_commitment || std::any_of(
+        pblock->vtx.begin(), pblock->vtx.end(),
+        [&](const CTransactionRef tx) { return tx->HasWitness(); }
+    )) {
+        pblocktemplate->vchCoinbaseCommitment = m_chainstate.m_chainman.GenerateCoinbaseCommitment(*pblock, pindexPrev);
+    }
 
     LogPrintf("CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
 

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -259,6 +259,17 @@ std::optional<BlockRef> GetTip(ChainstateManager& chainman);
 /* Waits for the connected tip to change until timeout has elapsed. During node initialization, this will wait until the tip is connected (regardless of `timeout`).
  * Returns the current tip, or nullopt if the node is shutting down. */
 std::optional<BlockRef> WaitTipChanged(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const uint256& current_tip, MillisecondsDouble& timeout);
+
+/*
+ * Extract relevant fields from the dummy coinbase transaction in the template.
+ *
+ * Extracts only OP_RETURN coinbase outputs, i.e. the witness commitment. If
+ * BlockAssembler::CreateNewBlock() is patched to add more OP_RETURN outputs
+ * e.g. for merge mining, those will be included. The dummy output that spends
+ * the full reward is excluded.
+ */
+node::CoinbaseTemplate ExtractCoinbaseTemplate(const node::CBlockTemplate& block_template);
+
 } // namespace node
 
 #endif // BITCOIN_NODE_MINER_H

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -16,10 +16,13 @@
 #include <consensus/amount.h>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <policy/policy.h>
+#include <primitives/transaction.h>
 #include <script/script.h>
 #include <uint256.h>
 #include <util/time.h>
+#include <vector>
 
 namespace node {
 enum class TransactionError {
@@ -97,6 +100,45 @@ struct BlockCheckOptions {
      * Set false to omit the proof-of-work check
      */
     bool check_pow{true};
+};
+
+struct CoinbaseTemplate {
+    /* nVersion */
+    uint32_t version;
+    /* nSequence for the only coinbase transaction input */
+    uint32_t sequence;
+    /**
+     * Bytes which are to be placed at the beginning of scriptSig. Guaranteed
+     * to be less than 8 bytes (not including the length byte). This allows
+     * clients to add up to 92 bytes.
+     */
+    CScript script_sig_prefix;
+    /**
+     * The first (and only) witness stack element of the coinbase input.
+     *
+     * Omitted for block templates without witness data.
+     *
+     * This is currently the BIP 141 witness reserved value. A future soft fork
+     * may move the witness reserved value elsewhere, but there will still be a
+     * coinbase witness.
+     */
+    std::optional<uint256> witness;
+    /**
+     * Block subsidy plus fees, minus any non-zero required_outputs.
+     *
+     * Currently there are no non-zero required_outputs, see below.
+     */
+    CAmount value_remaining;
+    /*
+     * To be included as the last outputs in the coinbase transaction.
+     * Currently this is only the witness commitment OP_RETURN, but future
+     * softforks could add more.
+     * If a patch to BlockAssembler::CreateNewBlock() adds outputs e.g. for
+     * merge mining, those will be included. The dummy output that spends
+     * the full reward is excluded.
+     */
+    std::vector<CTxOut> required_outputs;
+    uint32_t lock_time;
 };
 
 /**

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -67,6 +67,7 @@ struct BlockCreateOptions {
      * coinbase_max_additional_weight and coinbase_output_max_additional_sigops.
      */
     CScript coinbase_output_script{CScript() << OP_TRUE};
+
     /**
      * Whether to clear the dummy coinbase from the block template.
      *
@@ -75,6 +76,14 @@ struct BlockCreateOptions {
      * can opt-in to keeping it.
      */
     bool clear_coinbase{true};
+
+    /*
+     * Whether blocks without SegWit transactions (e.g. empty blocks) should
+     * have a SegWit commitment, i.e. the coinbase witness and OP_RETURN.
+     *
+     * @note IPC clients should omit this field for compatibility with v30.0
+     */
+    bool always_add_coinbase_commitment{false};
 };
 
 struct BlockWaitOptions {

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -139,6 +139,13 @@ struct CoinbaseTemplate {
      */
     std::vector<CTxOut> required_outputs;
     uint32_t lock_time;
+
+    /**
+     * Default witness commitment
+     *
+     * For getblocktemplate RPC, not exposed via IPC.
+     */
+    std::vector<unsigned char> default_witness_commitment;
 };
 
 /**

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -67,6 +67,14 @@ struct BlockCreateOptions {
      * coinbase_max_additional_weight and coinbase_output_max_additional_sigops.
      */
     CScript coinbase_output_script{CScript() << OP_TRUE};
+    /**
+     * Whether to clear the dummy coinbase from the block template.
+     *
+     * IPC clients are expected to call getCoinbase() rather than use the dummy
+     * transaction directly. It's cleared by default, but RPC and test code
+     * can opt-in to keeping it.
+     */
+    bool clear_coinbase{true};
 };
 
 struct BlockWaitOptions {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -167,7 +167,8 @@ static UniValue generateBlocks(ChainstateManager& chainman, Mining& miner, const
     while (nGenerate > 0 && !chainman.m_interrupt) {
         std::unique_ptr<BlockTemplate> block_template(miner.createNewBlock({
             .coinbase_output_script = coinbase_output_script,
-            .clear_coinbase = false
+            .clear_coinbase = false,
+            .always_add_coinbase_commitment = true
         }));
         CHECK_NONFATAL(block_template);
 
@@ -382,7 +383,8 @@ static RPCHelpMan generateblock()
             std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({
                 .use_mempool = false,
                 .coinbase_output_script = coinbase_output_script,
-                .clear_coinbase = false
+                .clear_coinbase = false,
+                .always_add_coinbase_commitment = true
             })};
             CHECK_NONFATAL(block_template);
 
@@ -878,7 +880,10 @@ static RPCHelpMan getblocktemplate()
         time_start = GetTime();
 
         // Create new block
-        block_template = miner.createNewBlock({.clear_coinbase = false});
+        block_template = miner.createNewBlock({
+            .clear_coinbase = false,
+            .always_add_coinbase_commitment = true
+        });
         CHECK_NONFATAL(block_template);
 
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -165,7 +165,10 @@ static UniValue generateBlocks(ChainstateManager& chainman, Mining& miner, const
 {
     UniValue blockHashes(UniValue::VARR);
     while (nGenerate > 0 && !chainman.m_interrupt) {
-        std::unique_ptr<BlockTemplate> block_template(miner.createNewBlock({ .coinbase_output_script = coinbase_output_script }));
+        std::unique_ptr<BlockTemplate> block_template(miner.createNewBlock({
+            .coinbase_output_script = coinbase_output_script,
+            .clear_coinbase = false
+        }));
         CHECK_NONFATAL(block_template);
 
         std::shared_ptr<const CBlock> block_out;
@@ -376,7 +379,11 @@ static RPCHelpMan generateblock()
     {
         LOCK(chainman.GetMutex());
         {
-            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({.use_mempool = false, .coinbase_output_script = coinbase_output_script})};
+            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({
+                .use_mempool = false,
+                .coinbase_output_script = coinbase_output_script,
+                .clear_coinbase = false
+            })};
             CHECK_NONFATAL(block_template);
 
             block = block_template->getBlock();
@@ -871,7 +878,7 @@ static RPCHelpMan getblocktemplate()
         time_start = GetTime();
 
         // Create new block
-        block_template = miner.createNewBlock();
+        block_template = miner.createNewBlock({.clear_coinbase = false});
         CHECK_NONFATAL(block_template);
 
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1015,8 +1015,9 @@ static RPCHelpMan getblocktemplate()
         result.pushKV("signet_challenge", HexStr(consensusParams.signet_challenge));
     }
 
-    if (!block_template->getCoinbaseCommitment().empty()) {
-        result.pushKV("default_witness_commitment", HexStr(block_template->getCoinbaseCommitment()));
+    auto default_witness_commitment{block_template->getCoinbase().default_witness_commitment};
+    if (!default_witness_commitment.empty()) {
+        result.pushKV("default_witness_commitment", HexStr(default_witness_commitment));
     }
 
     return result;

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -45,6 +45,7 @@ FUZZ_TARGET(utxo_total_supply)
     };
     BlockAssembler::Options options;
     options.coinbase_output_script = CScript() << OP_FALSE;
+    options.always_add_coinbase_commitment = true;
     const auto PrepareNextBlock = [&]() {
         // Use OP_FALSE to avoid BIP30 check from hitting early
         auto block = PrepareBlock(node, options);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -692,6 +692,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     CScript scriptPubKey = CScript() << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f"_hex << OP_CHECKSIG;
     BlockAssembler::Options options;
     options.coinbase_output_script = scriptPubKey;
+    options.clear_coinbase = false;
 
     // Create and check a simple template
     std::unique_ptr<BlockTemplate> block_template = mining->createNewBlock(options);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -404,6 +404,7 @@ CBlock TestChain100Setup::CreateBlock(
 {
     BlockAssembler::Options options;
     options.coinbase_output_script = scriptPubKey;
+    options.always_add_coinbase_commitment = true;
     CBlock block = BlockAssembler{chainstate, nullptr, options}.CreateNewBlock()->block;
 
     Assert(block.vtx.size() == 1);

--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -221,7 +221,7 @@ class IPCInterfaceTest(BitcoinTestFramework):
             opts.useMempool = True
             opts.blockReservedWeight = 4000
             opts.coinbaseOutputMaxAdditionalSigops = 0
-            template = mining.result.createNewBlock(opts)
+            template = mining.result.createNewBlock(ctx, opts)
             self.log.debug("Test some inspectors of Template")
             header = await template.result.getBlockHeader(ctx)
             assert_equal(len(header.result), block_header_size)
@@ -290,7 +290,7 @@ class IPCInterfaceTest(BitcoinTestFramework):
 
             current_block_height = self.nodes[0].getchaintips()[0]["height"]
             check_opts = self.capnp_modules['mining'].BlockCheckOptions()
-            template = await mining.result.createNewBlock(opts)
+            template = await mining.result.createNewBlock(ctx, opts)
             block = await self.parse_and_deserialize_block(template, ctx)
 
             coinbase = await self.build_coinbase_test(template, ctx, miniwallet)
@@ -305,7 +305,7 @@ class IPCInterfaceTest(BitcoinTestFramework):
             self.log.debug("Submit a block with a bad version")
             block.nVersion = 0
             block.solve()
-            res = await mining.result.checkBlock(block.serialize(), check_opts)
+            res = await mining.result.checkBlock(ctx, block.serialize(), check_opts)
             assert_equal(res.result, False)
             assert_equal(res.reason, "bad-version(0x00000000)")
             res = await template.result.submitSolution(ctx, block.nVersion, block.nTime, block.nNonce, coinbase.serialize())
@@ -315,7 +315,7 @@ class IPCInterfaceTest(BitcoinTestFramework):
             block.solve()
 
             self.log.debug("First call checkBlock()")
-            res = await mining.result.checkBlock(block.serialize(), check_opts)
+            res = await mining.result.checkBlock(ctx, block.serialize(), check_opts)
             assert_equal(res.result, True)
 
             # The remote template block will be mutated, capture the original:
@@ -345,7 +345,7 @@ class IPCInterfaceTest(BitcoinTestFramework):
             miniwallet.rescan_utxos()
             assert_equal(miniwallet.get_balance(), balance + 1)
             self.log.debug("Check block should fail now, since it is a duplicate")
-            res = await mining.result.checkBlock(block.serialize(), check_opts)
+            res = await mining.result.checkBlock(ctx, block.serialize(), check_opts)
             assert_equal(res.result, False)
             assert_equal(res.reason, "inconclusive-not-best-prevblk")
 

--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -8,7 +8,10 @@ from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
 import shutil
-from test_framework.blocktools import NULL_OUTPOINT
+from test_framework.blocktools import (
+    NULL_OUTPOINT,
+    WITNESS_COMMITMENT_HEADER,
+)
 from test_framework.messages import (
     CBlock,
     CTransaction,
@@ -168,13 +171,11 @@ class IPCInterfaceTest(BitcoinTestFramework):
         # Add SegWit OP_RETURN. This is currently always present even for
         # empty blocks, but this may change.
         found_witness_op_return = False
-        # Compare SegWit OP_RETURN to getCoinbaseCommitment()
-        coinbase_commitment = (await template.result.getCoinbaseCommitment(ctx)).result
         for output_data in coinbase_template.requiredOutputs:
             output = CTxOut()
             output.deserialize(BytesIO(output_data))
             coinbase.vout.append(output)
-            if output.scriptPubKey == coinbase_commitment:
+            if len(output.scriptPubKey) >= 6 and output.scriptPubKey[2:6] == WITNESS_COMMITMENT_HEADER:
                 found_witness_op_return = True
 
         assert_equal(has_witness, found_witness_op_return)

--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -182,13 +182,6 @@ class IPCInterfaceTest(BitcoinTestFramework):
 
         coinbase.nLockTime = coinbase_template.lockTime
 
-        # Compare to dummy coinbase provided by the deprecated getCoinbaseTx()
-        coinbase_legacy = await self.parse_and_deserialize_coinbase_tx(template, ctx)
-        assert_equal(coinbase_legacy.vout[0].nValue, coinbase_template.valueRemaining)
-        # Swap dummy output for our own
-        coinbase_legacy.vout[0].scriptPubKey = coinbase.vout[0].scriptPubKey
-        assert_equal(coinbase.serialize().hex(), coinbase_legacy.serialize().hex())
-
         return coinbase
 
     def run_mining_test(self):
@@ -239,11 +232,6 @@ class IPCInterfaceTest(BitcoinTestFramework):
             assert_equal(len(txfees.result), 0)
             txsigops = await template.result.getTxSigops(ctx)
             assert_equal(len(txsigops.result), 0)
-            # Inspect dummy coinbase returned by (deprecated) getCoinbaseTx()
-            coinbase_data = BytesIO((await template.result.getCoinbaseTx(ctx)).result)
-            coinbase = CTransaction()
-            coinbase.deserialize(coinbase_data)
-            assert_equal(coinbase.vin[0].prevout.hash, 0)
             self.log.debug("Wait for a new template")
             waitoptions = self.capnp_modules['mining'].BlockWaitOptions()
             waitoptions.timeout = timeout

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -63,6 +63,8 @@ COINBASE_MATURITY = 100
 # From BIP141
 WITNESS_COMMITMENT_HEADER = b"\xaa\x21\xa9\xed"
 
+NULL_OUTPOINT = COutPoint(0, 0xffffffff)
+
 NORMAL_GBT_REQUEST_PARAMS = {"rules": ["segwit"]}
 VERSIONBITS_LAST_OLD_BLOCK_VERSION = 4
 MIN_BLOCKS_TO_KEEP = 288
@@ -154,7 +156,7 @@ def create_coinbase(height, pubkey=None, *, script_pubkey=None, extra_output_scr
     script. This is useful to pad block weight/sigops as needed. """
     coinbase = CTransaction()
     coinbase.nLockTime = height - 1
-    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), script_BIP34_coinbase_height(height), MAX_SEQUENCE_NONFINAL))
+    coinbase.vin.append(CTxIn(NULL_OUTPOINT, script_BIP34_coinbase_height(height), MAX_SEQUENCE_NONFINAL))
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = nValue * COIN
     if nValue == 50:


### PR DESCRIPTION
I plan to split these into standalone pull requests in due time.

## Based on

- [ ] bitcoin/bitcoin#33819

## Non-breaking commits

**mining: deprecate getCoinbaseCommitment()**

Its value is only used by the `getblocktemplate` RPC and is redundant with the `required_outputs` fields of `getCoinbase()`

## Breaking commits

**mining: drop getCoinbaseTx(), etc**

This drops three deprecated methods:

- `getCoinbaseTx()`
- `getCoinbaseCommitment()`
- `getWitnessCommitmentIndex()`

**Pass context to `createNewBlock()` and `checkBlock()`**

- https://github.com/bitcoin/bitcoin/pull/33936

Adding a `context` parameter ensures that these methods are run in their own thread and don't block other calls.

This is especially important for checkBlock() which may receive a slow to validate block from an untrusted origin (the IPC connection itself is assumed to trusted).

This is a breaking change both ways:
- clients must use the updated capnp file
- updated clients can't call these methods on an unupgraded node

**Make non-mandatory coinbase commitment opt-in**

This adds `always_add_coinbase_commitment` to `BlockCreateOptions`

It could be carefully documented to avoid making it a breaking change, by telling clients to omit it for older Bitcoin Core versions. But it's easier as a breaking change.

Part of the test is commented out pending the newly proposed `getCoinbase()` method
