### PR TITLE
Witness transaction index

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -55,6 +55,7 @@ Subdirectory       | File(s)               | Description
 `blocks/`          | `xor.dat`             | Rolling XOR pattern for block and undo data files
 `chainstate/`      | LevelDB database      | Blockchain state (a compact representation of all currently unspent transaction outputs (UTXOs) and metadata about the transactions they are from)
 `indexes/txindex/` | LevelDB database      | Transaction index; *optional*, used if `-txindex=1`
+`indexes/wtxindex/` | LevelDB database     | Witness transaction index; *optional*, used if `-wtxindex=1`
 `indexes/txospenderindex/` | LevelDB database      | Transaction spender index; *optional*, used if `-txospenderindex=1`
 `indexes/blockfilter/basic/db/` | LevelDB database      | Blockfilter index LevelDB database for the basic filtertype; *optional*, used if `-blockfilterindex=basic`
 `indexes/blockfilter/basic/`    | `fltrNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Blockfilter index filters for the basic filtertype; *optional*, used if `-blockfilterindex=basic`

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 std::unique_ptr<TxIndex> g_txindex;
+std::unique_ptr<WtxIndex> g_wtxindex;
 
 namespace {
 SipHasher13UJ ReadOrCreateHasher(CDBWrapper& db)
@@ -261,3 +262,14 @@ TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, 
 }
 
 TxIndex::~TxIndex() = default;
+
+WtxIndex::WtxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
+    : BaseTransactionIndex(std::move(chain), n_cache_size, "wtxindex", "wtxidx", "wtxindex", /*has_legacy=*/false, f_memory, f_wipe)
+{}
+
+WtxIndex::~WtxIndex() = default;
+
+std::optional<TxIndexResult> WtxIndex::FindTx(const Wtxid& wtx_hash) const
+{
+    return BaseTransactionIndex::FindTx(wtx_hash.ToUint256(), /*active_only=*/true);
+}

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -41,28 +41,29 @@
 std::unique_ptr<TxIndex> g_txindex;
 
 namespace {
-SipHasher13UJ ReadOrCreateTxidHasher(CDBWrapper& db)
+SipHasher13UJ ReadOrCreateHasher(CDBWrapper& db)
 {
     std::pair<uint64_t, uint64_t> salt;
-    if (!db.Read(txindex::DB_TXID_HASH_SALT, salt)) {
+    if (!db.Read(txindex::DB_HASH_SALT, salt)) {
         FastRandomContext rng{};
         salt = {rng.rand64(), rng.rand64()};
-        db.Write(txindex::DB_TXID_HASH_SALT, salt, /*fSync=*/true);
+        db.Write(txindex::DB_HASH_SALT, salt, /*fSync=*/true);
     }
     return SipHasher13UJ{salt.first, salt.second};
 }
 } // namespace
 
-/** Access to the txindex database (indexes/txindex/) */
-class TxIndex::DB : public BaseIndex::DB
+/** Access to a transaction location index database. */
+class BaseTransactionIndex::DB : public BaseIndex::DB
 {
 public:
-    explicit DB(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit DB(const fs::path& path, size_t n_cache_size, bool has_legacy, bool f_memory = false, bool f_wipe = false);
 
     /// Write a block of transaction positions to the DB.
-    void WriteTxs(const interfaces::BlockInfo& block);
+    template <typename HashFn>
+    void WriteTxs(const interfaces::BlockInfo& block, HashFn&& get_hash);
 
-    /// Used to hash the txid to compute the prefix.
+    /// Used to hash the transaction identifier to compute the prefix.
     const SipHasher13UJ m_hasher;
 
     /// Whether the database contains any legacy ('t' + txid) entries.
@@ -70,30 +71,22 @@ public:
 
     CBlockLocator ReadBestBlock() const override;
     void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator) override;
-
-private:
-    DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool has_legacy);
 };
 
 static fs::path TxIndexDBPath() { return gArgs.GetDataDirNet() / "indexes" / "txindex"; }
 
-TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
+BaseTransactionIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool has_legacy, bool f_memory, bool f_wipe) :
     // Bloom filters are built for every key but only consulted by point reads,
     // which iterators bypass: the per-tx hashed ('x') lookups seek with an
     // iterator, and the 's'/'h' point reads are at most one per block against a
     // tiny keyspace. Only the legacy entries' per-tx point lookups benefit, so
     // enable the filters only for databases still containing them.
-    DB(n_cache_size, f_memory, f_wipe,
-       /*has_legacy=*/!f_memory && !f_wipe && CDBWrapper::HasKeyStartingWith(TxIndexDBPath(), txindex::DB_TXINDEX))
-{}
-
-TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool has_legacy) :
-    BaseIndex::DB(TxIndexDBPath(), n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/has_legacy),
-    m_hasher{ReadOrCreateTxidHasher(*this)},
+    BaseIndex::DB(path, n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/has_legacy),
+    m_hasher{ReadOrCreateHasher(*this)},
     m_has_legacy{has_legacy}
 {}
 
-CBlockLocator TxIndex::DB::ReadBestBlock() const
+CBlockLocator BaseTransactionIndex::DB::ReadBestBlock() const
 {
     CBlockLocator locator;
     if (Read(txindex::DB_BEST_BLOCK_V2, locator)) {
@@ -103,12 +96,13 @@ CBlockLocator TxIndex::DB::ReadBestBlock() const
     return BaseIndex::DB::ReadBestBlock();
 }
 
-void TxIndex::DB::WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator)
+void BaseTransactionIndex::DB::WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator)
 {
     batch.Write(txindex::DB_BEST_BLOCK_V2, locator);
 }
 
-void TxIndex::DB::WriteTxs(const interfaces::BlockInfo& block)
+template <typename HashFn>
+void BaseTransactionIndex::DB::WriteTxs(const interfaces::BlockInfo& block, HashFn&& get_hash)
 {
     // A block may be submitted again after it was already indexed, e.g. when it
     // reconnects after a reorg or is re-processed after an unclean shutdown. It
@@ -124,7 +118,7 @@ void TxIndex::DB::WriteTxs(const interfaces::BlockInfo& block)
     batch.Write(txindex::DB_NEXT_BLOCK_SEQ, block_seq + 1);
     uint32_t tx_offset_in_block{txindex::BLOCK_HEADER_SIZE + GetSizeOfCompactSize(block.data->vtx.size())};
     for (const auto& tx : block.data->vtx) {
-        const txindex::DBKey key{txindex::CreateKeyPrefix(m_hasher, tx->GetHash()),
+        const txindex::DBKey key{txindex::CreateKeyPrefix(m_hasher, get_hash(*tx)),
                                  txindex::BlockTxPosition{block_seq, tx_offset_in_block}};
         batch.Write(key, txindex::EMPTY_VALUE);
         tx_offset_in_block += tx->ComputeTotalSize();
@@ -132,31 +126,31 @@ void TxIndex::DB::WriteTxs(const interfaces::BlockInfo& block)
     WriteBatch(batch);
 }
 
-TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txindex", "txidx"), m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
+BaseTransactionIndex::BaseTransactionIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, std::string index_name, std::string thread_name, const char* path_name, bool has_legacy, bool f_memory, bool f_wipe)
+    : BaseIndex(std::move(chain), std::move(index_name), std::move(thread_name)),
+      m_db(std::make_unique<BaseTransactionIndex::DB>(gArgs.GetDataDirNet() / "indexes" / path_name, n_cache_size, has_legacy, f_memory, f_wipe))
+{}
+
+BaseTransactionIndex::~BaseTransactionIndex() = default;
+
+void BaseTransactionIndex::WriteBlock(const interfaces::BlockInfo& block) const
 {
-    if (m_db->m_has_legacy) {
-        LogInfo("txindex contains entries in the legacy format, which uses excessive disk space. "
-                "To reclaim disk space, stop the node, delete %s and restart to rebuild the index.",
-                fs::PathToString(TxIndexDBPath()));
-    }
+    m_db->WriteTxs(block, [this](const CTransaction& tx) { return GetHash(tx); });
 }
 
-TxIndex::~TxIndex() = default;
-
-bool TxIndex::CustomAppend(const interfaces::BlockInfo& block)
+bool BaseTransactionIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
     // Exclude genesis block transaction because outputs are not spendable.
     if (block.height == 0) return true;
 
     assert(block.data);
-    m_db->WriteTxs(block);
+    WriteBlock(block);
     return true;
 }
 
-BaseIndex::DB& TxIndex::GetDB() const { return *m_db; }
+BaseIndex::DB& BaseTransactionIndex::GetDB() const { return *m_db; }
 
-std::optional<TxIndexResult> TxIndex::FindTx(const Txid& tx_hash) const
+std::optional<TxIndexResult> BaseTransactionIndex::FindTx(const uint256& tx_hash, bool active_only) const
 {
     struct Candidate {
         FlatFilePos tx_position;
@@ -175,18 +169,19 @@ std::optional<TxIndexResult> TxIndex::FindTx(const Txid& tx_hash) const
         for (it->Seek(key); it->Valid() && it->GetKey(key) && key.hash_prefix == prefix; it->Next()) {
             uint256 candidate_block_hash;
             if (!m_db->Read(txindex::BlockSeqKey{key.pos.block_seq}, candidate_block_hash)) {
-                LogWarning("Block sequence %u not found for txid %s", key.pos.block_seq, tx_hash.ToString());
+                LogWarning("Block sequence %u not found for transaction %s", key.pos.block_seq, tx_hash.ToString());
                 continue;
             }
             LOCK(cs_main);
             const CBlockIndex* block_index{m_chainstate->m_blockman.LookupBlockIndex(candidate_block_hash)};
             if (!block_index) {
-                LogWarning("Block index entry %s not found for txid %s", candidate_block_hash.ToString(), tx_hash.ToString());
+                LogWarning("Block index entry %s not found for transaction %s", candidate_block_hash.ToString(), tx_hash.ToString());
                 continue;
             }
-            if (!(block_index->nStatus & BLOCK_HAVE_DATA)) continue;
+            const bool in_active_chain{m_chainstate->m_chain.Contains(*block_index)};
+            if (!(block_index->nStatus & BLOCK_HAVE_DATA) || (active_only && !in_active_chain)) continue;
             const FlatFilePos tx_position{block_index->nFile, block_index->nDataPos + key.pos.tx_offset_in_block};
-            candidates.emplace_back(tx_position, candidate_block_hash, key.pos.block_seq, m_chainstate->m_chain.Contains(*block_index));
+            candidates.emplace_back(tx_position, candidate_block_hash, key.pos.block_seq, in_active_chain);
         }
     }
 
@@ -198,7 +193,7 @@ std::optional<TxIndexResult> TxIndex::FindTx(const Txid& tx_hash) const
     for (const auto& candidate : candidates) {
         AutoFile file{m_chainstate->m_blockman.OpenBlockFile(candidate.tx_position, /*fReadOnly=*/true)};
         if (file.IsNull()) {
-            LogWarning("OpenBlockFile failed for txid %s", tx_hash.ToString());
+            LogWarning("OpenBlockFile failed for transaction %s", tx_hash.ToString());
             continue;
         }
         CTransactionRef tx;
@@ -208,9 +203,17 @@ std::optional<TxIndexResult> TxIndex::FindTx(const Txid& tx_hash) const
             LogWarning("Deserialize or I/O error - %s", e.what());
             continue;
         }
-        if (tx->GetHash() == tx_hash) {
+        if (GetHash(*tx) == tx_hash) {
             return TxIndexResult{candidate.block_hash, std::move(tx)};
         }
+    }
+    return std::nullopt;
+}
+
+std::optional<TxIndexResult> TxIndex::FindTx(const Txid& tx_hash) const
+{
+    if (const auto result{BaseTransactionIndex::FindTx(tx_hash.ToUint256(), /*active_only=*/false)}) {
+        return result;
     }
     // Fall back to legacy if no hashed entry matched. This makes misses pay an
     // extra lookup, but keeps existing full-txid entries readable after upgrade.
@@ -245,3 +248,16 @@ std::optional<TxIndexResult> TxIndex::FindLegacyTx(const Txid& tx_hash) const
     }
     return TxIndexResult{header.GetHash(), std::move(tx)};
 }
+
+TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
+    : BaseTransactionIndex(std::move(chain), n_cache_size, "txindex", "txidx", "txindex",
+                           /*has_legacy=*/!f_memory && !f_wipe && CDBWrapper::HasKeyStartingWith(TxIndexDBPath(), txindex::DB_TXINDEX), f_memory, f_wipe)
+{
+    if (m_db->m_has_legacy) {
+        LogInfo("txindex contains entries in the legacy format, which uses excessive disk space. "
+                "To reclaim disk space, stop the node, delete %s and restart to rebuild the index.",
+                fs::PathToString(TxIndexDBPath()));
+    }
+}
+
+TxIndex::~TxIndex() = default;

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -6,12 +6,14 @@
 #define BITCOIN_INDEX_TXINDEX_H
 
 #include <index/base.h>
+#include <kernel/chain.h>
 #include <primitives/transaction.h>
 #include <uint256.h>
 
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <string>
 
 namespace interfaces {
 class Chain;
@@ -29,37 +31,64 @@ struct TxIndexResult {
 };
 
 /**
- * TxIndex is used to look up transactions included in the blockchain by hash.
+ * BaseTransactionIndex is used to look up transactions included in the blockchain by hash.
  * The index is written to a LevelDB database and records the block sequence
- * number and serialized block offset of each transaction by transaction hash.
+ * number and serialized block offset of each transaction by transaction identifier.
  */
-class TxIndex final : public BaseIndex
+class BaseTransactionIndex : public BaseIndex
 {
 protected:
     class DB;
 
 private:
     friend class txindex_tests::TxIndexTest;
-    const std::unique_ptr<DB> m_db;
-
-    bool AllowPrune() const override { return false; }
-
-    /// Look up a transaction among the legacy (full-txid) entries.
-    std::optional<TxIndexResult> FindLegacyTx(const Txid& tx_hash) const;
 
 protected:
+    const std::unique_ptr<DB> m_db;
+
+private:
+    bool AllowPrune() const override { return false; }
+
+protected:
+    /// Constructs the index, which becomes available to be queried.
+    explicit BaseTransactionIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, std::string index_name, std::string thread_name, const char* path_name, bool has_legacy, bool f_memory = false, bool f_wipe = false);
+
+    /// Write the transaction locations for this index's key format.
+    void WriteBlock(const interfaces::BlockInfo& block) const;
+
+    /// Return the identifier this index uses for a transaction.
+    virtual uint256 GetHash(const CTransaction& tx) const = 0;
+
     bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     BaseIndex::DB& GetDB() const override;
+
+    /// Look up a transaction by its index-specific identifier.
+    std::optional<TxIndexResult> FindTx(const uint256& tx_hash, bool active_only) const;
+
+public:
+    // Destructor is declared because this class contains a unique_ptr to an incomplete type.
+    virtual ~BaseTransactionIndex() override;
+};
+
+/**
+ * TxIndex is used to look up transactions included in the blockchain by txid.
+ */
+class TxIndex final : public BaseTransactionIndex
+{
+private:
+    uint256 GetHash(const CTransaction& tx) const override { return tx.GetHash().ToUint256(); }
+
+    /// Look up a transaction among the legacy (full-txid) entries.
+    std::optional<TxIndexResult> FindLegacyTx(const Txid& tx_hash) const;
 
 public:
     /// Constructs the index, which becomes available to be queried.
     explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
-    // Destructor is declared because this class contains a unique_ptr to an incomplete type.
     virtual ~TxIndex() override;
 
-    /// Look up a transaction by hash.
+    /// Look up a transaction by txid.
     ///
     /// @param[in]   tx_hash  The hash of the transaction to be returned.
     /// @return  the transaction and containing block hash, or nullopt if it is not found

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -23,6 +23,7 @@ class TxIndexTest;
 }
 
 inline constexpr bool DEFAULT_TXINDEX{false};
+inline constexpr bool DEFAULT_WTXINDEX{false};
 
 /// A found transaction and the hash of the block that contains it.
 struct TxIndexResult {
@@ -95,7 +96,30 @@ public:
     std::optional<TxIndexResult> FindTx(const Txid& tx_hash) const;
 };
 
+/**
+ * WtxIndex is used to look up transactions included in the blockchain by wtxid.
+ */
+class WtxIndex final : public BaseTransactionIndex
+{
+private:
+    uint256 GetHash(const CTransaction& tx) const override { return tx.GetWitnessHash().ToUint256(); }
+
+public:
+    /// Constructs the index, which becomes available to be queried.
+    explicit WtxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+
+    virtual ~WtxIndex() override;
+
+    /// Look up a transaction by wtxid.
+    ///
+    /// @param[in]   wtx_hash  The witness hash of the transaction to be returned.
+    /// @return  the transaction and containing block hash, or nullopt if it is not found
+    std::optional<TxIndexResult> FindTx(const Wtxid& wtx_hash) const;
+};
+
 /// The global transaction index, used in GetTransaction. May be null.
 extern std::unique_ptr<TxIndex> g_txindex;
+/// The global witness transaction index. May be null.
+extern std::unique_ptr<WtxIndex> g_wtxindex;
 
 #endif // BITCOIN_INDEX_TXINDEX_H

--- a/src/index/txindex_key.h
+++ b/src/index/txindex_key.h
@@ -26,7 +26,7 @@ namespace txindex {
  *   ['s', block seq]                         -> block hash
  *   ['h', block hash]                        -> block seq
  *   ["next_block_seq"]                       -> next block seq to assign
- *   ["txid_hash_salt"]                       -> txid hasher salt
+ *   ["txid_hash_salt"]                       -> transaction identifier hasher salt
  *   ["best_block_v2"]                        -> current sync locator
  *   ['t', txid]                              -> legacy CDiskTxPos
  *   ['B']                                    -> legacy sync locator
@@ -36,7 +36,7 @@ constexpr uint8_t DB_TXINDEX_HASHED{'x'};
 constexpr uint8_t DB_BLOCK_SEQ{'s'};
 constexpr uint8_t DB_BLOCK_HASH{'h'};
 inline const std::string DB_NEXT_BLOCK_SEQ{"next_block_seq"};
-inline const std::string DB_TXID_HASH_SALT{"txid_hash_salt"};
+inline const std::string DB_HASH_SALT{"txid_hash_salt"};
 inline const std::string DB_BEST_BLOCK_V2{"best_block_v2"};
 //! Prefix of a legacy (pre-hashing) txindex row.
 constexpr uint8_t DB_TXINDEX{'t'};
@@ -99,9 +99,15 @@ struct BlockHashKey {
 constexpr int HASH_PREFIX_SIZE{5};
 using TxHashKeyPrefix = uint64_t;
 
-inline TxHashKeyPrefix CreateKeyPrefix(const SipHasher13UJ& hasher, const Txid& txid)
+inline TxHashKeyPrefix CreateKeyPrefix(const SipHasher13UJ& hasher, const uint256& tx_hash)
 {
-    return hasher.Hash(txid.ToUint256()) >> (8 * (sizeof(TxHashKeyPrefix) - HASH_PREFIX_SIZE));
+    return hasher.Hash(tx_hash) >> (8 * (sizeof(TxHashKeyPrefix) - HASH_PREFIX_SIZE));
+}
+
+template <typename TxHash>
+inline TxHashKeyPrefix CreateKeyPrefix(const SipHasher13UJ& hasher, const TxHash& tx_hash)
+{
+    return CreateKeyPrefix(hasher, tx_hash.ToUint256());
 }
 
 struct DBKey {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -392,6 +392,7 @@ void Shutdown(NodeContext& node)
     // Stop and delete all indexes only after flushing background callbacks.
     for (auto* index : node.indexes) index->Stop();
     if (g_txindex) g_txindex.reset();
+    if (g_wtxindex) g_wtxindex.reset();
     if (g_txospenderindex) g_txospenderindex.reset();
     if (g_coin_stats_index) g_coin_stats_index.reset();
     DestroyAllBlockFilterIndexes();
@@ -547,7 +548,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                              DEFAULT_PERSIST_V1_DAT),
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-pid=<file>", strprintf("Specify pid file. Relative paths will be prefixed by a net-specific datadir location. (default: %s)", BITCOIN_PID_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-prune=<n>", strprintf("Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex. "
+    argsman.AddArg("-prune=<n>", strprintf("Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex and -wtxindex. "
             "Warning: Reverting this setting requires re-downloading the entire blockchain. Wallets and indexes should be loaded at startup and kept active while pruning is enabled so they stay synchronized before old block data is deleted; wallets or indexes that fall behind pruned data may require a reindex. "
             "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >=%u = automatically prune block files to stay under the specified target size in MiB)", MIN_DISK_SPACE_FOR_BLOCK_FILES / 1_MiB), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex", "If enabled, wipe chain state and block index, and rebuild them from blk*.dat files on disk. Also wipe and rebuild other optional indexes that are active. If an assumeutxo snapshot was loaded, its chainstate will be wiped as well. The snapshot can then be reloaded via RPC.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -558,6 +559,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-shutdownnotify=<cmd>", "Execute command immediately before beginning shutdown. The need for shutdown may be urgent, so be careful not to delay it long (if the command doesn't require interaction with the server, consider having it fork into the background).", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif
     argsman.AddArg("-txindex", strprintf("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)", DEFAULT_TXINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-wtxindex", strprintf("Maintain a full witness transaction index by wtxid (default: %u)", DEFAULT_WTXINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-txospenderindex", strprintf("Maintain a transaction output spender index, used by the gettxspendingprevout rpc call (default: %u)", DEFAULT_TXOSPENDERINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blockfilterindex=<type>",
                  strprintf("Maintain an index of compact filters by block (default: %s, values: %s).", DEFAULT_BLOCKFILTERINDEX, ListBlockFilterTypes()) +
@@ -1038,6 +1040,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     if (args.GetIntArg("-prune", 0)) {
         if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX))
             return InitError(_("Prune mode is incompatible with -txindex."));
+        if (args.GetBoolArg("-wtxindex", DEFAULT_WTXINDEX))
+            return InitError(_("Prune mode is incompatible with -wtxindex."));
         if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX))
             return InitError(_("Prune mode is incompatible with -txospenderindex."));
         if (args.GetBoolArg("-reindex-chainstate", false)) {
@@ -1867,6 +1871,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
         LogInfo("* Using %.1f MiB for transaction index database", index_cache_sizes.tx_index / double(1_MiB));
     }
+    if (args.GetBoolArg("-wtxindex", DEFAULT_WTXINDEX)) {
+        LogInfo("* Using %.1f MiB for witness transaction index database", index_cache_sizes.wtx_index / double(1_MiB));
+    }
     if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {
         LogInfo("* Using %.1f MiB for transaction output spender index database", index_cache_sizes.txospender_index / double(1_MiB));
     }
@@ -1936,6 +1943,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
         g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex);
         node.indexes.emplace_back(g_txindex.get());
+    }
+
+    if (args.GetBoolArg("-wtxindex", DEFAULT_WTXINDEX)) {
+        g_wtxindex = std::make_unique<WtxIndex>(interfaces::MakeChain(node), index_cache_sizes.wtx_index, false, do_reindex);
+        node.indexes.emplace_back(g_wtxindex.get());
     }
 
     if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -24,6 +24,8 @@
 // a meaningful difference: https://github.com/bitcoin/bitcoin/pull/8273#issuecomment-229601991
 //! Max memory allocated to tx index DB specific cache in bytes.
 static constexpr uint64_t MAX_TX_INDEX_CACHE{1_GiB};
+//! Max memory allocated to wtx index DB specific cache in bytes.
+static constexpr uint64_t MAX_WTX_INDEX_CACHE{1_GiB};
 //! Max memory allocated to all block filter index caches combined in bytes.
 static constexpr uint64_t MAX_FILTER_INDEX_CACHE{1_GiB};
 //! Max memory allocated to tx spenderindex DB specific cache in bytes.
@@ -61,6 +63,8 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
     // Allocate proportional to usage pattern benefit:
     // - txindex (10%): serves getrawtransaction RPCs with mostly unique,
     //   non-repetitive lookups across the entire blockchain.
+    // - wtxindex (10%): serves wtxid lookups with the same usage pattern as
+    //   txindex.
     // - blockfilterindex (5%): serves BIP 157 light clients that repeatedly
     //   query recent blocks, benefiting from LevelDB cache, but the
     //   working set for a typical 2-week offline gap is ~200kiB, well within 5%
@@ -71,6 +75,7 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
     //   does not seem to suggest it would be necessary to cache.
     IndexCacheSizes index_sizes;
     index_sizes.tx_index = std::min(total_cache * 10 / 100, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? MAX_TX_INDEX_CACHE : 0);
+    index_sizes.wtx_index = std::min(total_cache * 10 / 100, args.GetBoolArg("-wtxindex", DEFAULT_WTXINDEX) ? MAX_WTX_INDEX_CACHE : 0);
     index_sizes.txospender_index = std::min(total_cache * 5 / 100, args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX) ? MAX_TXOSPENDER_INDEX_CACHE : 0);
     if (n_indexes > 0) {
         uint64_t max_cache = std::min(total_cache * 5 / 100, MAX_FILTER_INDEX_CACHE);
@@ -78,6 +83,7 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
         total_cache -= index_sizes.filter_index * n_indexes;
     }
     total_cache -= index_sizes.tx_index;
+    total_cache -= index_sizes.wtx_index;
     total_cache -= index_sizes.txospender_index;
     return {index_sizes, kernel::CacheSizes{total_cache}};
 }

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -21,6 +21,7 @@ namespace node {
 uint64_t GetDefaultDBCache();
 struct IndexCacheSizes {
     uint64_t tx_index{0};
+    uint64_t wtx_index{0};
     uint64_t filter_index{0};
     uint64_t txospender_index{0};
 };

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -389,6 +389,10 @@ static RPCMethod getindexinfo()
         result.pushKVs(SummaryToJSON(g_txindex->GetSummary(), index_name));
     }
 
+    if (g_wtxindex) {
+        result.pushKVs(SummaryToJSON(g_wtxindex->GetSummary(), index_name));
+    }
+
     if (g_coin_stats_index) {
         result.pushKVs(SummaryToJSON(g_coin_stats_index->GetSummary(), index_name));
     }

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -42,9 +42,9 @@ BOOST_AUTO_TEST_SUITE(txindex_tests)
 class TxIndexTest
 {
 public:
-    static CDBWrapper& GetDB(const TxIndex& txindex) { return txindex.GetDB(); }
-    static CBlockLocator ReadBestBlock(const TxIndex& txindex) { return txindex.GetDB().ReadBestBlock(); }
-    static void WriteBestBlock(const TxIndex& txindex, const CBlockLocator& locator)
+    static CDBWrapper& GetDB(const BaseTransactionIndex& txindex) { return txindex.GetDB(); }
+    static CBlockLocator ReadBestBlock(const BaseTransactionIndex& txindex) { return txindex.GetDB().ReadBestBlock(); }
+    static void WriteBestBlock(const BaseTransactionIndex& txindex, const CBlockLocator& locator)
     {
         auto& db{txindex.GetDB()};
         CDBBatch batch{db};
@@ -58,7 +58,7 @@ namespace {
 SipHasher13UJ ReadHasher(const CDBWrapper& db)
 {
     std::pair<uint64_t, uint64_t> salt;
-    BOOST_REQUIRE(db.Read(txindex::DB_TXID_HASH_SALT, salt));
+    BOOST_REQUIRE(db.Read(txindex::DB_HASH_SALT, salt));
     return SipHasher13UJ{salt.first, salt.second};
 }
 

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -352,4 +352,111 @@ BOOST_FIXTURE_TEST_CASE(txindex_reorg_keeps_stale_entries, TestChain100Setup)
     txindex.Stop();
 }
 
+BOOST_FIXTURE_TEST_CASE(wtxindex_initial_sync, TestChain100Setup)
+{
+    WtxIndex wtxindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/true);
+    BOOST_REQUIRE(wtxindex.Init());
+
+    // Transaction should not be found in the index before it is started.
+    for (const auto& txn : m_coinbase_txns) {
+        BOOST_CHECK(!wtxindex.FindTx(txn->GetWitnessHash()));
+    }
+
+    // BlockUntilSyncedToCurrentChain should return false before wtxindex is started.
+    BOOST_CHECK(!wtxindex.BlockUntilSyncedToCurrentChain());
+
+    wtxindex.Sync();
+
+    // Check that wtxindex excludes genesis block transactions.
+    const CBlock& genesis_block = Params().GenesisBlock();
+    for (const auto& txn : genesis_block.vtx) {
+        BOOST_CHECK(!wtxindex.FindTx(txn->GetWitnessHash()));
+    }
+
+    // Check that wtxindex has all txs that were in the chain before it started.
+    for (const auto& txn : m_coinbase_txns) {
+        const auto result{wtxindex.FindTx(txn->GetWitnessHash())};
+        BOOST_REQUIRE(result);
+        BOOST_CHECK(result->tx->GetWitnessHash() == txn->GetWitnessHash());
+    }
+
+    // Check that new transactions in new blocks make it into the index.
+    for (int i = 0; i < 10; i++) {
+        CScript coinbase_script_pub_key = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
+        std::vector<CMutableTransaction> no_txns;
+        const CBlock& block = CreateAndProcessBlock(no_txns, coinbase_script_pub_key);
+        const CTransaction& txn = *block.vtx[0];
+
+        BOOST_CHECK(wtxindex.BlockUntilSyncedToCurrentChain());
+        const auto result{wtxindex.FindTx(txn.GetWitnessHash())};
+        BOOST_REQUIRE(result);
+        BOOST_CHECK(result->tx->GetWitnessHash() == txn.GetWitnessHash());
+    }
+
+    // shutdown sequence (c.f. Shutdown() in init.cpp)
+    wtxindex.Stop();
+}
+
+BOOST_FIXTURE_TEST_CASE(wtxindex_collision_scan_path, TestChain100Setup)
+{
+    WtxIndex wtxindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/true);
+    BOOST_REQUIRE(wtxindex.Init());
+    wtxindex.Sync();
+
+    CDBWrapper& db{TxIndexTest::GetDB(wtxindex)};
+    const SipHasher13UJ hasher{ReadHasher(db)};
+
+    const Wtxid fake_wtxid{m_coinbase_txns.back()->GetWitnessHash()};
+    const Wtxid target_wtxid{m_coinbase_txns.front()->GetWitnessHash()};
+    const auto fake_prefix{txindex::CreateKeyPrefix(hasher, fake_wtxid)};
+    const auto target_prefix{txindex::CreateKeyPrefix(hasher, target_wtxid)};
+    BOOST_REQUIRE(fake_prefix != target_prefix);
+
+    const auto fake_bucket{BucketPositions(db, fake_prefix)};
+    BOOST_REQUIRE_EQUAL(fake_bucket.size(), 1U);
+    const txindex::BlockTxPosition fake_pos{fake_bucket.front()};
+    db.Write(txindex::DBKey{target_prefix, fake_pos}, txindex::EMPTY_VALUE);
+
+    const auto result{wtxindex.FindTx(target_wtxid)};
+    BOOST_REQUIRE(result);
+    BOOST_CHECK(result->tx->GetWitnessHash() == target_wtxid);
+
+    db.Erase(txindex::DBKey{target_prefix, fake_pos});
+    wtxindex.Stop();
+}
+
+BOOST_FIXTURE_TEST_CASE(wtxindex_reorg_ignores_stale_entries, TestChain100Setup)
+{
+    WtxIndex wtxindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/true);
+    BOOST_REQUIRE(wtxindex.Init());
+    wtxindex.Sync();
+
+    const CScript stale_coinbase_script{CScript() << OP_TRUE};
+    const CBlock& stale_block{CreateAndProcessBlock({}, stale_coinbase_script)};
+    const Wtxid stale_wtxid{stale_block.vtx.front()->GetWitnessHash()};
+    BOOST_REQUIRE(wtxindex.BlockUntilSyncedToCurrentChain());
+
+    const auto result{wtxindex.FindTx(stale_wtxid)};
+    BOOST_REQUIRE(result);
+    BOOST_CHECK(result->tx->GetWitnessHash() == stale_wtxid);
+    const uint256 stale_block_hash{result->block_hash};
+
+    ChainstateManager& chainman{*m_node.chainman};
+    {
+        CBlockIndex* tip{WITH_LOCK(cs_main, return chainman.ActiveChain().Tip())};
+        BOOST_REQUIRE(tip->GetBlockHash() == stale_block_hash);
+        BlockValidationState state;
+        BOOST_REQUIRE(chainman.ActiveChainstate().InvalidateBlock(state, tip));
+    }
+
+    const CScript replacement_coinbase_script{CScript() << OP_FALSE};
+    CreateAndProcessBlock({}, replacement_coinbase_script);
+    CreateAndProcessBlock({}, replacement_coinbase_script);
+    BOOST_REQUIRE(wtxindex.BlockUntilSyncedToCurrentChain());
+
+    BOOST_CHECK(!wtxindex.FindTx(stale_wtxid));
+
+    wtxindex.Stop();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -20,6 +20,7 @@ from test_framework.util import assert_equal
 
 ALL_INDEX_ARGS = [
     '-txindex=1',
+    '-wtxindex=1',
     '-blockfilterindex=1',
     '-coinstatsindex=1',
     '-txospenderindex=1',
@@ -79,6 +80,7 @@ class InitTest(BitcoinTestFramework):
             b'addcon thread start',
             b'initload thread start',
             b'txidx thread start',
+            b'wtxidx thread start',
             b'blkfltbscidx thread start',
             b'coinstatsidx thread start',
             b'txospenderidx thread start',
@@ -146,6 +148,11 @@ class InitTest(BitcoinTestFramework):
                 'startup_args': ['-txindex=1'],
             },
             {
+                'filepath_glob': 'indexes/wtxindex/MANIFEST*',
+                'error_message': 'LevelDB error: Corruption: CURRENT points to a non-existent file',
+                'startup_args': ['-wtxindex=1'],
+            },
+            {
                 'filepath_glob': 'indexes/txospenderindex/db/MANIFEST*',
                 'error_message': 'LevelDB error: Corruption: CURRENT points to a non-existent file',
                 'startup_args': ['-txospenderindex=1'],
@@ -190,6 +197,16 @@ class InitTest(BitcoinTestFramework):
                 'filepath_glob': 'indexes/txindex/CURRENT',
                 'error_message': 'LevelDB error: Corruption',
                 'startup_args': ['-txindex=1'],
+            },
+            {
+                'filepath_glob': 'indexes/wtxindex/*.log',
+                'error_message': 'LevelDB error: Corruption',
+                'startup_args': ['-wtxindex=1'],
+            },
+            {
+                'filepath_glob': 'indexes/wtxindex/CURRENT',
+                'error_message': 'LevelDB error: Corruption',
+                'startup_args': ['-wtxindex=1'],
             },
             {
                 'filepath_glob': 'indexes/txospenderindex/db/*',

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -128,6 +128,10 @@ class PruneTest(BitcoinTestFramework):
             extra_args=['-prune=550', '-txindex'],
         )
         self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Prune mode is incompatible with -wtxindex.',
+            extra_args=['-prune=550', '-wtxindex'],
+        )
+        self.nodes[0].assert_start_raises_init_error(
             expected_msg='Error: Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.',
             extra_args=['-prune=550', '-reindex-chainstate'],
         )

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -99,7 +99,7 @@ class RpcMiscTest(BitcoinTestFramework):
         assert_equal(node.getindexinfo(), {})
 
         # Restart the node with indices and wait for them to sync
-        self.restart_node(0, ["-txindex", "-blockfilterindex", "-coinstatsindex", "-txospenderindex"])
+        self.restart_node(0, ["-txindex", "-wtxindex", "-blockfilterindex", "-coinstatsindex", "-txospenderindex"])
         self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
 
         # Returns a list of all running indices by default
@@ -108,13 +108,14 @@ class RpcMiscTest(BitcoinTestFramework):
             node.getindexinfo(),
             {
                 "txindex": values,
+                "wtxindex": values,
                 "basic block filter index": values,
                 "coinstatsindex": values,
                 "txospenderindex": values,
             }
         )
         # Specifying an index by name returns only the status of that index
-        for i in {"txindex", "basic block filter index", "coinstatsindex", "txospenderindex"}:
+        for i in {"txindex", "wtxindex", "basic block filter index", "coinstatsindex", "txospenderindex"}:
             assert_equal(node.getindexinfo(i), {i: values})
 
         # Specifying an unknown index name returns an empty result


### PR DESCRIPTION
Kind of hoping we don't need this.

This uses the new encoding from https://github.com/bitcoin/bitcoin/pull/35531. The `-txindex` needs to support both encodings, while `-wtxindex` doesn't need to be backward compatible.

_100% vibe coded_

Can be combined with #116, see #118. 