### PR TITLE
TxCollection with background coin prefetch

### DIFF
--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(bench_bitcoin
   sign_transaction.cpp
   streams_findbyte.cpp
   strencodings.cpp
+  tx_collection.cpp
   txgraph.cpp
   txorphanage.cpp
   util_time.cpp

--- a/src/bench/tx_collection.cpp
+++ b/src/bench/tx_collection.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addresstype.h>
+#include <bench/bench.h>
+#include <coins.h>
+#include <consensus/amount.h>
+#include <key.h>
+#include <node/miner.h>
+#include <primitives/transaction.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/check.h>
+#include <validation.h>
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+//! Number of transactions in the collection, and inputs per transaction. The
+//! resulting template spends NUM_TXS * INPUTS_PER_TX coins from the UTXO set.
+constexpr size_t NUM_TXS{1000};
+constexpr size_t INPUTS_PER_TX{2};
+
+/** Common state for the TxCollection benchmarks: a chain whose UTXO set
+ *  contains NUM_TXS * INPUTS_PER_TX confirmed and flushed-to-disk coins, and
+ *  a set of valid transactions spending them. */
+struct CollectionSetup {
+    std::unique_ptr<TestChain100Setup> test_setup{MakeNoLogFileContext<TestChain100Setup>()};
+    std::vector<CTransactionRef> txs;
+    std::vector<Wtxid> wtxids;
+    std::vector<COutPoint> prevouts;
+    uint256 tip;
+
+    CollectionSetup()
+    {
+        Chainstate& chainstate{test_setup->m_node.chainman->ActiveChainstate()};
+        const CKey key{GenerateRandomKey()};
+        const CTxOut txout{COIN / 100, GetScriptForDestination(WitnessV1Taproot{XOnlyPubKey(key.GetPubKey())})};
+        const std::vector<CKey> keys{test_setup->coinbaseKey, key};
+
+        // Confirm a transaction creating all the coins the collected
+        // transactions will spend, then flush them to disk so MakeTemplate()
+        // with a cold cache has to read them back.
+        auto& coinbase_to_spend{test_setup->m_coinbase_txns[0]};
+        const auto [funding_tx, _]{test_setup->CreateValidTransaction(
+            {coinbase_to_spend},
+            {COutPoint(coinbase_to_spend->GetHash(), 0)},
+            chainstate.m_chain.Height() + 1, keys,
+            std::vector<CTxOut>(NUM_TXS * INPUTS_PER_TX, txout), {}, {})};
+        test_setup->CreateAndProcessBlock({funding_tx}, txout.scriptPubKey);
+
+        const CTransactionRef funding_ref{MakeTransactionRef(funding_tx)};
+        for (size_t i{0}; i < NUM_TXS; ++i) {
+            std::vector<COutPoint> inputs;
+            for (size_t j{0}; j < INPUTS_PER_TX; ++j) {
+                inputs.emplace_back(funding_ref->GetHash(), i * INPUTS_PER_TX + j);
+            }
+            const auto [tx, _fee]{test_setup->CreateValidTransaction(
+                {funding_ref}, inputs, chainstate.m_chain.Height(), {key},
+                {txout}, {}, {})};
+            txs.push_back(MakeTransactionRef(tx));
+            wtxids.push_back(txs.back()->GetWitnessHash());
+            prevouts.insert(prevouts.end(), inputs.begin(), inputs.end());
+        }
+
+        chainstate.ForceFlushStateToDisk();
+        tip = WITH_LOCK(cs_main, return chainstate.m_chain.Tip()->GetBlockHash());
+    }
+
+    //! Evict the collected transactions' input coins from the coins cache, so
+    //! the next MakeTemplate() has to read them from the coins database.
+    void UncacheInputs()
+    {
+        LOCK(cs_main);
+        CCoinsViewCache& coins{test_setup->m_node.chainman->ActiveChainstate().CoinsTip()};
+        for (const auto& outpoint : prevouts) coins.Uncache(outpoint);
+    }
+};
+
+//! Template creation when every input coin has to be read from disk.
+void TxCollectionTemplateColdCoins(benchmark::Bench& bench)
+{
+    CollectionSetup setup;
+    node::TxCollection collection{setup.wtxids, setup.test_setup->m_node};
+    collection.AddMissingTxs(setup.txs);
+    collection.WaitForPrefetch();
+
+    std::string reason, debug;
+    bench.unit("template").run([&] {
+        setup.UncacheInputs();
+        const auto block_template{collection.MakeTemplate(setup.tip, /*coinbase=*/nullptr, reason, debug)};
+        assert(block_template);
+    });
+}
+
+//! Template creation after the background prefetch has warmed the coins
+//! cache. The difference with TxCollectionTemplateColdCoins is the latency
+//! that prefetching removes from the critical path.
+void TxCollectionTemplatePrefetchedCoins(benchmark::Bench& bench)
+{
+    CollectionSetup setup;
+    node::TxCollection collection{setup.wtxids, setup.test_setup->m_node};
+    collection.AddMissingTxs(setup.txs);
+    collection.WaitForPrefetch();
+
+    std::string reason, debug;
+    bench.unit("template").run([&] {
+        const auto block_template{collection.MakeTemplate(setup.tip, /*coinbase=*/nullptr, reason, debug)};
+        assert(block_template);
+    });
+}
+
+//! The prefetch itself: collect the transactions and wait for their input
+//! coins to be cached. In real usage this overlaps with the client's request
+//! for missing transactions, so it does not add to template latency.
+void TxCollectionPrefetch(benchmark::Bench& bench)
+{
+    CollectionSetup setup;
+
+    bench.unit("collection").run([&] {
+        setup.UncacheInputs();
+        node::TxCollection collection{setup.wtxids, setup.test_setup->m_node};
+        collection.AddMissingTxs(setup.txs);
+        collection.WaitForPrefetch();
+    });
+}
+
+} // namespace
+
+BENCHMARK(TxCollectionTemplateColdCoins);
+BENCHMARK(TxCollectionTemplatePrefetchedCoins);
+BENCHMARK(TxCollectionPrefetch);

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -102,6 +102,18 @@ public:
     virtual void interruptWait() = 0;
 };
 
+/**
+ * Collect transactions in a client-specified order.
+ *
+ * Usage:
+ * - Call Mining::collectTxs() with the requested wtxids in final block order.
+ */
+class TxCollection
+{
+public:
+    virtual ~TxCollection() = default;
+};
+
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)
 //! ability to create block templates.
 class Mining
@@ -203,6 +215,14 @@ public:
      *                     transaction if found, otherwise nullptr
      */
     virtual std::vector<CTransactionRef> getTransactionsByWitnessID(const std::vector<Wtxid>& wtxids) = 0;
+
+    /**
+     * Look up transactions by witness id and keep references to any that are
+     * currently in the mempool.
+     *
+     * @throws std::runtime_error if the same wtxid is requested more than once.
+     */
+    virtual std::unique_ptr<TxCollection> collectTxs(const std::vector<Wtxid>& wtxids) = 0;
 
     //! Get internal node context. Useful for RPC and testing,
     //! but not accessible across processes.

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -37,12 +37,15 @@ public:
     // it may not match a transaction constructed from getCoinbaseTx().
     virtual CBlock getBlock() = 0;
 
-    // Fees per transaction, not including coinbase transaction.
+    // Fees per transaction, not including coinbase transaction. Throws for
+    // externally generated templates.
     virtual std::vector<CAmount> getTxFees() = 0;
-    // Sigop cost per transaction, not including coinbase transaction.
+    // Sigop cost per transaction, not including coinbase transaction. Throws
+    // for externally generated templates.
     virtual std::vector<int64_t> getTxSigops() = 0;
 
-    /** Return fields needed to construct a coinbase transaction */
+    /** Return fields needed to construct a coinbase transaction.
+     * Throws for externally generated templates. */
     virtual node::CoinbaseTx getCoinbaseTx() = 0;
 
     /**
@@ -93,6 +96,8 @@ public:
      *
      * On testnet this will additionally return a template with difficulty 1 if
      * the tip is more than 20 minutes old.
+     *
+     * Throws for externally generated templates.
      */
     virtual std::unique_ptr<BlockTemplate> waitNext(node::BlockWaitOptions options = {}) = 0;
 

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -107,11 +107,15 @@ public:
  *
  * Usage:
  * - Call Mining::collectTxs() with the requested wtxids in final block order.
+ * - Use unknownTxPos() to learn which transactions are still missing.
  */
 class TxCollection
 {
 public:
     virtual ~TxCollection() = default;
+
+    //! Return the zero-based positions of transactions that are still missing.
+    virtual std::vector<uint32_t> unknownTxPos() = 0;
 };
 
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -108,6 +108,7 @@ public:
  * Usage:
  * - Call Mining::collectTxs() with the requested wtxids in final block order.
  * - Use unknownTxPos() to learn which transactions are still missing.
+ * - Provide missing transactions with addMissingTxs().
  */
 class TxCollection
 {
@@ -116,6 +117,17 @@ public:
 
     //! Return the zero-based positions of transactions that are still missing.
     virtual std::vector<uint32_t> unknownTxPos() = 0;
+
+    /**
+     * Add transactions that were missing from the initial collection.
+     *
+     * The list is checked for null entries and unexpected wtxids before any
+     * transaction is added, so a failed call leaves the collection unchanged.
+     *
+     * @throws std::runtime_error on a null transaction, or a wtxid that was
+     *         not among those requested.
+     */
+    virtual void addMissingTxs(const std::vector<CTransactionRef>& txs) = 0;
 };
 
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -103,12 +103,15 @@ public:
 };
 
 /**
- * Collect transactions in a client-specified order.
+ * Collect transactions in a client-specified order and later assemble and
+ * validate them as a block template.
  *
  * Usage:
  * - Call Mining::collectTxs() with the requested wtxids in final block order.
  * - Use unknownTxPos() to learn which transactions are still missing.
  * - Provide missing transactions with addMissingTxs().
+ * - Once all requested transactions are available, call makeTemplate() to
+ *   validate the requested prevhash and build a block template.
  */
 class TxCollection
 {
@@ -128,6 +131,40 @@ public:
      *         not among those requested.
      */
     virtual void addMissingTxs(const std::vector<CTransactionRef>& txs) = 0;
+
+    /**
+     * Construct a block template using the collected transactions in their
+     * requested order.
+     *
+     * Requires all requested transactions to be present, and prevhash to
+     * match the current tip.
+     *
+     * The resulting block is validated with the same final TestBlockValidity()
+     * call used by checkBlock(), with the proof-of-work and merkle-root checks
+     * disabled.
+     *
+     * Possible @p reason values:
+     * - `missing-txs`: one or more requested transactions have not been
+     *   provided yet
+     * - `stale-prevblk`: the requested prevhash is an ancestor of the
+     *   current tip
+     * - `inconclusive-not-best-prevblk`: the requested prevhash does not
+     *   match the current tip and is not in the active chain (e.g. it is
+     *   on a fork, or the node has not seen it yet)
+     * - otherwise BIP-22 style
+     *
+     * @param[in] prevhash hash of the tip the template must build on top of
+     * @param[in] coinbase optional coinbase transaction to validate the block
+     *                     with. When null, a node-generated dummy
+     *                     coinbase is used.
+     * @param[out] reason  failure reason; see above
+     * @param[out] debug   more detailed rejection reason
+     * @returns            block template on success, otherwise nullptr
+     */
+    virtual std::unique_ptr<BlockTemplate> makeTemplate(uint256 prevhash,
+                                                        CTransactionRef coinbase,
+                                                        std::string& reason,
+                                                        std::string& debug) = 0;
 };
 
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -28,6 +28,11 @@ interface Mining $Proxy.wrap("interfaces::Mining") {
     submitBlock @7 (context :Proxy.Context, block: Data) -> (reason: Text, debug: Text, result: Bool);
     getTransactionsByTxID @8 (context :Proxy.Context, txids: List(Data)) -> (result: List(Data));
     getTransactionsByWitnessID @9 (context :Proxy.Context, wtxids: List(Data)) -> (result: List(Data));
+    collectTxs @10 (context :Proxy.Context, wtxids: List(Data)) -> (result: TxCollection);
+}
+
+interface TxCollection $Proxy.wrap("interfaces::TxCollection") {
+    destroy @0 (context :Proxy.Context) -> ();
 }
 
 interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -33,6 +33,7 @@ interface Mining $Proxy.wrap("interfaces::Mining") {
 
 interface TxCollection $Proxy.wrap("interfaces::TxCollection") {
     destroy @0 (context :Proxy.Context) -> ();
+    unknownTxPos @1 (context: Proxy.Context) -> (result: List(UInt32));
 }
 
 interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -35,6 +35,7 @@ interface TxCollection $Proxy.wrap("interfaces::TxCollection") {
     destroy @0 (context :Proxy.Context) -> ();
     unknownTxPos @1 (context: Proxy.Context) -> (result: List(UInt32));
     addMissingTxs @2 (context: Proxy.Context, txs: List(Data)) -> ();
+    makeTemplate @3 (context: Proxy.Context, prevhash: Data, coinbase: Data) -> (reason: Text, debug: Text, result: BlockTemplate);
 }
 
 interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -34,6 +34,7 @@ interface Mining $Proxy.wrap("interfaces::Mining") {
 interface TxCollection $Proxy.wrap("interfaces::TxCollection") {
     destroy @0 (context :Proxy.Context) -> ();
     unknownTxPos @1 (context: Proxy.Context) -> (result: List(UInt32));
+    addMissingTxs @2 (context: Proxy.Context, txs: List(Data)) -> ();
 }
 
 interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -965,6 +965,11 @@ public:
         return m_collected_txs.UnknownTxPos();
     }
 
+    void addMissingTxs(const std::vector<CTransactionRef>& txs) override
+    {
+        m_collected_txs.AddMissingTxs(txs);
+    }
+
 private:
     node::TxCollection m_collected_txs;
 };

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -956,7 +956,8 @@ class TxCollectionImpl : public interfaces::TxCollection
 {
 public:
     TxCollectionImpl(std::vector<Wtxid> wtxids, const NodeContext& node)
-        : m_collected_txs(std::move(wtxids), node)
+        : m_collected_txs(std::move(wtxids), node),
+          m_node(node)
     {
     }
 
@@ -970,8 +971,19 @@ public:
         m_collected_txs.AddMissingTxs(txs);
     }
 
+    std::unique_ptr<BlockTemplate> makeTemplate(uint256 prevhash,
+                                                CTransactionRef coinbase,
+                                                std::string& reason,
+                                                std::string& debug) override
+    {
+        auto block_template{m_collected_txs.MakeTemplate(prevhash, coinbase, reason, debug)};
+        if (!block_template) return nullptr;
+        return std::make_unique<BlockTemplateImpl>(BlockCreateOptions{}, std::move(block_template), m_node);
+    }
+
 private:
     node::TxCollection m_collected_txs;
+    const NodeContext& m_node;
 };
 
 class MinerImpl : public Mining

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -952,6 +952,18 @@ public:
     const NodeContext& m_node;
 };
 
+class TxCollectionImpl : public interfaces::TxCollection
+{
+public:
+    TxCollectionImpl(std::vector<Wtxid> wtxids, const NodeContext& node)
+        : m_collected_txs(std::move(wtxids), node)
+    {
+    }
+
+private:
+    node::TxCollection m_collected_txs;
+};
+
 class MinerImpl : public Mining
 {
 public:
@@ -1051,6 +1063,11 @@ public:
             results.emplace_back(m_node.mempool->get(wtxid));
         }
         return results;
+    }
+
+    std::unique_ptr<interfaces::TxCollection> collectTxs(const std::vector<Wtxid>& wtxids) override
+    {
+        return std::make_unique<TxCollectionImpl>(wtxids, m_node);
     }
 
     const NodeContext* context() override { return &m_node; }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -78,6 +78,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -880,9 +881,11 @@ class BlockTemplateImpl : public BlockTemplate
 public:
     explicit BlockTemplateImpl(BlockCreateOptions create_options,
                                std::unique_ptr<CBlockTemplate> block_template,
-                               const NodeContext& node) : m_create_options(std::move(create_options)),
-                                                          m_block_template(std::move(block_template)),
-                                                          m_node(node)
+                               const NodeContext& node,
+                               bool external = false) : m_create_options(std::move(create_options)),
+                                                        m_block_template(std::move(block_template)),
+                                                        m_external(external),
+                                                        m_node(node)
     {
         assert(m_block_template);
     }
@@ -899,16 +902,19 @@ public:
 
     std::vector<CAmount> getTxFees() override
     {
+        if (m_external) throw std::runtime_error("getTxFees is unavailable for externally generated templates");
         return m_block_template->vTxFees;
     }
 
     std::vector<int64_t> getTxSigops() override
     {
+        if (m_external) throw std::runtime_error("getTxSigops is unavailable for externally generated templates");
         return m_block_template->vTxSigOpsCost;
     }
 
     CoinbaseTx getCoinbaseTx() override
     {
+        if (m_external) throw std::runtime_error("getCoinbaseTx is unavailable for externally generated templates");
         return m_block_template->m_coinbase_tx;
     }
 
@@ -926,6 +932,7 @@ public:
 
     std::unique_ptr<BlockTemplate> waitNext(BlockWaitOptions options) override
     {
+        if (m_external) throw std::runtime_error("waitNext is unavailable for externally generated templates");
         auto new_template = WaitAndCreateNewBlock(chainman(),
                                                   notifications(),
                                                   m_node.mempool.get(),
@@ -933,7 +940,7 @@ public:
                                                   /*wait_options=*/options,
                                                   /*create_options=*/m_create_options,
                                                   /*interrupt_wait=*/m_interrupt_wait);
-        if (new_template) return std::make_unique<BlockTemplateImpl>(m_create_options, std::move(new_template), m_node);
+        if (new_template) return std::make_unique<BlockTemplateImpl>(m_create_options, std::move(new_template), m_node, m_external);
         return nullptr;
     }
 
@@ -946,6 +953,7 @@ public:
 
     const std::unique_ptr<CBlockTemplate> m_block_template;
 
+    const bool m_external;
     bool m_interrupt_wait{false};
     ChainstateManager& chainman() { return *Assert(m_node.chainman); }
     KernelNotifications& notifications() { return *Assert(m_node.notifications); }
@@ -978,7 +986,7 @@ public:
     {
         auto block_template{m_collected_txs.MakeTemplate(prevhash, coinbase, reason, debug)};
         if (!block_template) return nullptr;
-        return std::make_unique<BlockTemplateImpl>(BlockCreateOptions{}, std::move(block_template), m_node);
+        return std::make_unique<BlockTemplateImpl>(BlockCreateOptions{}, std::move(block_template), m_node, /*external=*/true);
     }
 
 private:

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -960,6 +960,11 @@ public:
     {
     }
 
+    std::vector<uint32_t> unknownTxPos() override
+    {
+        return m_collected_txs.UnknownTxPos();
+    }
+
 private:
     node::TxCollection m_collected_txs;
 };

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -16,6 +16,7 @@
 #include <consensus/validation.h>
 #include <interfaces/types.h>
 #include <node/blockstorage.h>
+#include <node/context.h>
 #include <node/kernel_notifications.h>
 #include <node/mining_args.h>
 #include <node/mining_types.h>
@@ -32,6 +33,7 @@
 #include <uint256.h>
 #include <util/check.h>
 #include <util/feefrac.h>
+#include <util/hasher.h>
 #include <util/log.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
@@ -42,6 +44,7 @@
 #include <versionbits.h>
 
 #include <algorithm>
+#include <boost/multi_index/detail/hash_index_iterator.hpp>
 #include <compare>
 #include <condition_variable>
 #include <cstddef>
@@ -50,9 +53,26 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 namespace node {
+
+TxCollection::TxCollection(std::vector<Wtxid> wtxids, const NodeContext& node)
+    : m_wtxids(std::move(wtxids)),
+      m_node(node)
+{
+    CTxMemPool& mempool{*Assert(m_node.mempool)};
+    LOCK(mempool.cs);
+    for (const auto& wtxid : m_wtxids) {
+        const auto it{mempool.GetIter(wtxid)};
+        CTransactionRef tx{it ? (*it)->GetSharedTx() : nullptr};
+        if (!m_transactions.emplace(wtxid, std::move(tx)).second) {
+            throw std::runtime_error(strprintf("duplicate wtxid %s", wtxid.ToString()));
+        }
+    }
+}
+
 
 int64_t GetMinimumTime(const CBlockIndex* pindexPrev, const int64_t difficulty_adjustment_interval)
 {

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -73,6 +73,16 @@ TxCollection::TxCollection(std::vector<Wtxid> wtxids, const NodeContext& node)
     }
 }
 
+std::vector<uint32_t> TxCollection::UnknownTxPos() const
+{
+    std::vector<uint32_t> result;
+    for (size_t i{0}; i < m_wtxids.size(); ++i) {
+        // Every requested wtxid is a key (added in the constructor), so at()
+        // is safe; a null value means the transaction is still missing.
+        if (!m_transactions.at(m_wtxids[i])) result.push_back(static_cast<uint32_t>(i));
+    }
+    return result;
+}
 
 int64_t GetMinimumTime(const CBlockIndex* pindexPrev, const int64_t difficulty_adjustment_interval)
 {

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -172,6 +172,73 @@ void BlockAssembler::resetBlock()
     nFees = 0;
 }
 
+CoinbaseTx BlockAssembler::CreateCoinbaseTx(CBlock& block,
+                                            const CBlockIndex& pindexPrev,
+                                            CAmount fees)
+{
+    Assert(!block.vtx.empty());
+    nHeight = pindexPrev.nHeight + 1;
+
+    // Create coinbase transaction.
+    CMutableTransaction coinbaseTx;
+
+    // Construct coinbase transaction struct in parallel
+    CoinbaseTx coinbase_tx;
+    coinbase_tx.version = coinbaseTx.version;
+
+    coinbaseTx.vin.resize(1);
+    coinbaseTx.vin[0].prevout.SetNull();
+    coinbaseTx.vin[0].nSequence = CTxIn::MAX_SEQUENCE_NONFINAL; // Make sure timelock is enforced.
+    coinbase_tx.sequence = coinbaseTx.vin[0].nSequence;
+
+    // Add an output that spends the full coinbase reward.
+    coinbaseTx.vout.resize(1);
+    coinbaseTx.vout[0].scriptPubKey = m_options.coinbase_output_script;
+    // Block subsidy + fees
+    const CAmount block_reward{fees + GetBlockSubsidy(nHeight, chainparams.GetConsensus())};
+    coinbaseTx.vout[0].nValue = block_reward;
+    coinbase_tx.block_reward_remaining = block_reward;
+
+    // Start the coinbase scriptSig with the block height as required by BIP34.
+    // Mining clients are expected to append extra data to this prefix, so
+    // increasing its length would reduce the space they can use and may break
+    // existing clients.
+    coinbaseTx.vin[0].scriptSig = CScript() << nHeight;
+    // Set script_sig_prefix here, so IPC mining clients are not affected by
+    // the optional scriptSig padding below. They provide their own extraNonce,
+    // and in a typical setup a pool name or realistic extraNonce already makes
+    // the scriptSig long enough.
+    coinbase_tx.script_sig_prefix = coinbaseTx.vin[0].scriptSig;
+    if (nHeight <= 16) {
+        // For blocks at heights <= 16, the BIP34-encoded height alone is only
+        // one byte. Consensus requires coinbase scriptSigs to be at least two
+        // bytes long (bad-cb-length), so an OP_0 is always appended at those
+        // heights.
+        coinbaseTx.vin[0].scriptSig << OP_0;
+    }
+    Assert(nHeight > 0);
+    coinbaseTx.nLockTime = static_cast<uint32_t>(nHeight - 1);
+    coinbase_tx.lock_time = coinbaseTx.nLockTime;
+
+    block.vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
+    m_chainstate.m_chainman.GenerateCoinbaseCommitment(block, &pindexPrev);
+
+    const CTransactionRef& final_coinbase{block.vtx[0]};
+    if (final_coinbase->HasWitness()) {
+        const auto& witness_stack{final_coinbase->vin[0].scriptWitness.stack};
+        // Consensus requires the coinbase witness stack to have exactly one
+        // element of 32 bytes.
+        Assert(witness_stack.size() == 1 && witness_stack[0].size() == 32);
+        coinbase_tx.witness = uint256(witness_stack[0]);
+    }
+    if (const int witness_index = GetWitnessCommitmentIndex(block); witness_index != NO_WITNESS_COMMITMENT) {
+        Assert(witness_index >= 0 && static_cast<size_t>(witness_index) < final_coinbase->vout.size());
+        coinbase_tx.required_outputs.push_back(final_coinbase->vout[witness_index]);
+    }
+
+    return coinbase_tx;
+}
+
 std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
 {
     const auto time_start{SteadyClock::now()};
@@ -212,62 +279,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     m_last_block_num_txs = nBlockTx;
     m_last_block_weight = nBlockWeight;
 
-    // Create coinbase transaction.
-    CMutableTransaction coinbaseTx;
-
-    // Construct coinbase transaction struct in parallel
-    CoinbaseTx& coinbase_tx{pblocktemplate->m_coinbase_tx};
-    coinbase_tx.version = coinbaseTx.version;
-
-    coinbaseTx.vin.resize(1);
-    coinbaseTx.vin[0].prevout.SetNull();
-    coinbaseTx.vin[0].nSequence = CTxIn::MAX_SEQUENCE_NONFINAL; // Make sure timelock is enforced.
-    coinbase_tx.sequence = coinbaseTx.vin[0].nSequence;
-
-    // Add an output that spends the full coinbase reward.
-    coinbaseTx.vout.resize(1);
-    coinbaseTx.vout[0].scriptPubKey = m_options.coinbase_output_script;
-    // Block subsidy + fees
-    const CAmount block_reward{nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus())};
-    coinbaseTx.vout[0].nValue = block_reward;
-    coinbase_tx.block_reward_remaining = block_reward;
-
-    // Start the coinbase scriptSig with the block height as required by BIP34.
-    // Mining clients are expected to append extra data to this prefix, so
-    // increasing its length would reduce the space they can use and may break
-    // existing clients.
-    coinbaseTx.vin[0].scriptSig = CScript() << nHeight;
-    // Set script_sig_prefix here, so IPC mining clients are not affected by
-    // the optional scriptSig padding below. They provide their own extraNonce,
-    // and in a typical setup a pool name or realistic extraNonce already makes
-    // the scriptSig long enough.
-    coinbase_tx.script_sig_prefix = coinbaseTx.vin[0].scriptSig;
-    if (nHeight <= 16) {
-        // For blocks at heights <= 16, the BIP34-encoded height alone is only
-        // one byte. Consensus requires coinbase scriptSigs to be at least two
-        // bytes long (bad-cb-length), so an OP_0 is always appended at those
-        // heights.
-        coinbaseTx.vin[0].scriptSig << OP_0;
-    }
-    Assert(nHeight > 0);
-    coinbaseTx.nLockTime = static_cast<uint32_t>(nHeight - 1);
-    coinbase_tx.lock_time = coinbaseTx.nLockTime;
-
-    pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
-    m_chainstate.m_chainman.GenerateCoinbaseCommitment(*pblock, pindexPrev);
-
-    const CTransactionRef& final_coinbase{pblock->vtx[0]};
-    if (final_coinbase->HasWitness()) {
-        const auto& witness_stack{final_coinbase->vin[0].scriptWitness.stack};
-        // Consensus requires the coinbase witness stack to have exactly one
-        // element of 32 bytes.
-        Assert(witness_stack.size() == 1 && witness_stack[0].size() == 32);
-        coinbase_tx.witness = uint256(witness_stack[0]);
-    }
-    if (const int witness_index = GetWitnessCommitmentIndex(*pblock); witness_index != NO_WITNESS_COMMITMENT) {
-        Assert(witness_index >= 0 && static_cast<size_t>(witness_index) < final_coinbase->vout.size());
-        coinbase_tx.required_outputs.push_back(final_coinbase->vout[witness_index]);
-    }
+    pblocktemplate->m_coinbase_tx = CreateCoinbaseTx(*pblock, *pindexPrev, nFees);
 
     LogInfo("CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -103,6 +103,92 @@ void TxCollection::AddMissingTxs(const std::vector<CTransactionRef>& txs)
     }
 }
 
+std::unique_ptr<CBlockTemplate> TxCollection::MakeTemplate(const uint256& prevhash,
+                                                           const CTransactionRef& coinbase,
+                                                           std::string& reason,
+                                                           std::string& debug)
+{
+    reason.clear();
+    debug.clear();
+
+    auto block_template{[&]() -> std::unique_ptr<CBlockTemplate> {
+        LOCK(m_mutex);
+        if (std::ranges::any_of(m_transactions, [](const auto& entry) { return !entry.second; })) {
+            reason = "missing-txs";
+            debug = "collected transaction(s) still missing";
+            return nullptr;
+        }
+        ChainstateManager& chainman{*Assert(m_node.chainman)};
+        LOCK(chainman.GetMutex());
+        const auto current_tip{GetTip(chainman)};
+        if (!current_tip || prevhash != current_tip->hash) {
+            const CBlockIndex* prev_block{chainman.m_blockman.LookupBlockIndex(prevhash)};
+            if (prev_block && chainman.ActiveChain().Contains(*prev_block)) {
+                reason = "stale-prevblk";
+            } else {
+                reason = "inconclusive-not-best-prevblk";
+            }
+            debug = strprintf("requested prevhash %s does not match current tip %s",
+                              prevhash.ToString(),
+                              current_tip ? current_tip->hash.ToString() : "(none)");
+            return nullptr;
+        }
+        const CBlockIndex* const prev_block{Assert(chainman.m_blockman.LookupBlockIndex(prevhash))};
+        auto block_template{std::make_unique<CBlockTemplate>()};
+        CBlock& block{block_template->block};
+
+        block.hashPrevBlock = prevhash;
+        block.nVersion = chainman.m_versionbitscache.ComputeBlockVersion(prev_block, chainman.GetParams().GetConsensus());
+        if (chainman.GetParams().MineBlocksOnDemand()) {
+            block.nVersion = gArgs.GetIntArg("-blockversion", block.nVersion);
+        }
+        block.nTime = TicksSinceEpoch<std::chrono::seconds>(NodeClock::now());
+
+        // Placeholder for the coinbase tx, filled in after the collected
+        // transactions are added so the witness commitment is current.
+        block.vtx.emplace_back();
+
+        for (const auto& wtxid : m_wtxids) {
+            const auto it{m_transactions.find(wtxid)};
+            Assume(it != m_transactions.end());
+            Assume(it->second);
+            block.vtx.push_back(it->second);
+        }
+
+        if (coinbase) {
+            // Validate the block with the caller-provided coinbase, which is
+            // expected to commit to the collected transactions (witness
+            // commitment) and the next block height (BIP34).
+            block.vtx[0] = coinbase;
+        } else {
+            // Validate with a node-generated dummy coinbase. Checks involving the
+            // coinbase still pass, but say nothing about the coinbase the caller
+            // intends to use.
+            BlockAssembler{
+                chainman.ActiveChainstate(),
+                m_node.mempool.get(),
+                BlockCreateOptions{.use_mempool = false},
+            }.CreateCoinbaseTx(block, *prev_block, /*fees=*/0);
+        }
+
+        UpdateTime(&block, chainman.GetParams().GetConsensus(), prev_block);
+        block.nBits = GetNextWorkRequired(prev_block, &block, chainman.GetParams().GetConsensus());
+        block.nNonce = 0;
+
+        BlockValidationState state{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/false)};
+        if (!state.IsValid()) {
+            reason = state.GetRejectReason();
+            debug = state.GetDebugMessage();
+            return nullptr;
+        }
+        return block_template;
+    }()};
+    // This follows the SubmitBlock convention: a missing template must set a
+    // rejection reason, and a successful one must not.
+    CHECK_NONFATAL((block_template != nullptr) == reason.empty());
+    return block_template;
+}
+
 int64_t GetMinimumTime(const CBlockIndex* pindexPrev, const int64_t difficulty_adjustment_interval)
 {
     int64_t min_time{pindexPrev->GetMedianTimePast() + 1};

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -62,6 +62,7 @@ TxCollection::TxCollection(std::vector<Wtxid> wtxids, const NodeContext& node)
     : m_wtxids(std::move(wtxids)),
       m_node(node)
 {
+    LOCK(m_mutex);
     CTxMemPool& mempool{*Assert(m_node.mempool)};
     LOCK(mempool.cs);
     for (const auto& wtxid : m_wtxids) {
@@ -75,6 +76,7 @@ TxCollection::TxCollection(std::vector<Wtxid> wtxids, const NodeContext& node)
 
 std::vector<uint32_t> TxCollection::UnknownTxPos() const
 {
+    LOCK(m_mutex);
     std::vector<uint32_t> result;
     for (size_t i{0}; i < m_wtxids.size(); ++i) {
         // Every requested wtxid is a key (added in the constructor), so at()
@@ -82,6 +84,23 @@ std::vector<uint32_t> TxCollection::UnknownTxPos() const
         if (!m_transactions.at(m_wtxids[i])) result.push_back(static_cast<uint32_t>(i));
     }
     return result;
+}
+
+void TxCollection::AddMissingTxs(const std::vector<CTransactionRef>& txs)
+{
+    LOCK(m_mutex);
+    // Check for null entries and unexpected wtxids before adding any
+    // transaction, so a failed call leaves the collection unchanged.
+    for (const auto& tx : txs) {
+        if (!tx) throw std::runtime_error("unexpected null transaction");
+        if (!m_transactions.contains(tx->GetWitnessHash())) {
+            throw std::runtime_error(strprintf("unexpected wtxid %s", tx->GetWitnessHash().ToString()));
+        }
+    }
+    for (const auto& tx : txs) {
+        auto& entry{m_transactions.at(tx->GetWitnessHash())};
+        if (!entry) entry = tx;
+    }
 }
 
 int64_t GetMinimumTime(const CBlockIndex* pindexPrev, const int64_t difficulty_adjustment_interval)

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -7,6 +7,7 @@
 
 #include <chain.h>
 #include <chainparams.h>
+#include <coins.h>
 #include <common/args.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
@@ -37,6 +38,7 @@
 #include <util/log.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
+#include <util/thread.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
@@ -54,24 +56,109 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace node {
+
+//! Number of input coins the prefetch thread fetches per cs_main acquisition,
+//! so it does not hold up validation for the duration of a full block's worth
+//! of coin database reads.
+static constexpr size_t PREFETCH_BATCH_SIZE{128};
 
 TxCollection::TxCollection(std::vector<Wtxid> wtxids, const NodeContext& node)
     : m_wtxids(std::move(wtxids)),
       m_node(node)
 {
-    LOCK(m_mutex);
-    CTxMemPool& mempool{*Assert(m_node.mempool)};
-    LOCK(mempool.cs);
-    for (const auto& wtxid : m_wtxids) {
-        const auto it{mempool.GetIter(wtxid)};
-        CTransactionRef tx{it ? (*it)->GetSharedTx() : nullptr};
-        if (!m_transactions.emplace(wtxid, std::move(tx)).second) {
-            throw std::runtime_error(strprintf("duplicate wtxid %s", wtxid.ToString()));
+    {
+        LOCK(m_mutex);
+        CTxMemPool& mempool{*Assert(m_node.mempool)};
+        std::vector<CTransactionRef> found;
+        {
+            LOCK(mempool.cs);
+            for (const auto& wtxid : m_wtxids) {
+                const auto it{mempool.GetIter(wtxid)};
+                CTransactionRef tx{it ? (*it)->GetSharedTx() : nullptr};
+                if (tx) found.push_back(tx);
+                if (!m_transactions.emplace(wtxid, std::move(tx)).second) {
+                    throw std::runtime_error(strprintf("duplicate wtxid %s", wtxid.ToString()));
+                }
+            }
+        }
+        QueuePrefetch(found);
+    }
+    // Start the prefetch thread only after the collection is fully
+    // constructed. Coins are loaded in the background while the client
+    // learns which transactions are missing and provides them.
+    m_prefetch_thread = std::thread(&util::TraceThread, "txprefetch", [this] { PrefetchThread(); });
+}
+
+TxCollection::~TxCollection()
+{
+    {
+        LOCK(m_mutex);
+        m_prefetch_stop = true;
+    }
+    m_prefetch_cv.notify_all();
+    if (m_prefetch_thread.joinable()) m_prefetch_thread.join();
+}
+
+void TxCollection::QueuePrefetch(const std::vector<CTransactionRef>& txs)
+{
+    AssertLockHeld(m_mutex);
+    // Inputs spending another collected transaction do not have a coin in the
+    // UTXO set. This misses spends of a transaction that is added later, which
+    // merely costs a cheap negative coin database lookup.
+    std::unordered_set<Txid, SaltedTxidHasher> collected;
+    for (const auto& [_, tx] : m_transactions) {
+        if (tx) collected.insert(tx->GetHash());
+    }
+    for (const auto& tx : txs) {
+        for (const auto& txin : tx->vin) {
+            if (!collected.contains(txin.prevout.hash)) m_prefetch_queue.push_back(txin.prevout);
         }
     }
+    if (!m_prefetch_queue.empty()) m_prefetch_cv.notify_all();
+}
+
+void TxCollection::PrefetchThread()
+{
+    while (true) {
+        std::vector<COutPoint> batch;
+        {
+            WAIT_LOCK(m_mutex, lock);
+            m_prefetch_cv.wait(lock, [this]() EXCLUSIVE_LOCKS_REQUIRED(m_mutex) {
+                return m_prefetch_stop || !m_prefetch_queue.empty();
+            });
+            if (m_prefetch_stop) return;
+            m_prefetch_busy = true;
+            const size_t n{std::min(PREFETCH_BATCH_SIZE, m_prefetch_queue.size())};
+            batch.assign(m_prefetch_queue.begin(), m_prefetch_queue.begin() + n);
+            m_prefetch_queue.erase(m_prefetch_queue.begin(), m_prefetch_queue.begin() + n);
+        }
+        {
+            ChainstateManager& chainman{*Assert(m_node.chainman)};
+            LOCK(chainman.GetMutex());
+            // HaveCoin() pulls the coin from disk into the cache; a coin
+            // fetched this way is clean, so it does not grow the next flush
+            // and can be evicted at any time.
+            CCoinsViewCache& coins{chainman.ActiveChainstate().CoinsTip()};
+            for (const auto& outpoint : batch) coins.HaveCoin(outpoint);
+        }
+        {
+            LOCK(m_mutex);
+            m_prefetch_busy = false;
+            if (m_prefetch_queue.empty()) m_prefetch_cv.notify_all();
+        }
+    }
+}
+
+void TxCollection::WaitForPrefetch()
+{
+    WAIT_LOCK(m_mutex, lock);
+    m_prefetch_cv.wait(lock, [this]() EXCLUSIVE_LOCKS_REQUIRED(m_mutex) {
+        return m_prefetch_stop || (m_prefetch_queue.empty() && !m_prefetch_busy);
+    });
 }
 
 std::vector<uint32_t> TxCollection::UnknownTxPos() const
@@ -97,10 +184,15 @@ void TxCollection::AddMissingTxs(const std::vector<CTransactionRef>& txs)
             throw std::runtime_error(strprintf("unexpected wtxid %s", tx->GetWitnessHash().ToString()));
         }
     }
+    std::vector<CTransactionRef> added;
     for (const auto& tx : txs) {
         auto& entry{m_transactions.at(tx->GetWitnessHash())};
-        if (!entry) entry = tx;
+        if (!entry) {
+            entry = tx;
+            added.push_back(tx);
+        }
     }
+    QueuePrefetch(added);
 }
 
 std::unique_ptr<CBlockTemplate> TxCollection::MakeTemplate(const uint256& prevhash,

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -87,6 +87,18 @@ public:
 
     /** Construct a new block template */
     std::unique_ptr<CBlockTemplate> CreateNewBlock();
+    /**
+     * Create a coinbase transaction and insert it into block.vtx[0].
+     *
+     * @param[in,out] block       Block whose coinbase transaction is replaced.
+     * @param[in]     pindexPrev  Previous block index. Used to derive the
+     *                            coinbase height, subsidy, and commitment.
+     * @param[in]     fees        Fees to add to the block subsidy.
+     * @return                    Metadata describing the inserted coinbase.
+     */
+    CoinbaseTx CreateCoinbaseTx(CBlock& block,
+                                const CBlockIndex& pindexPrev,
+                                CAmount fees);
 
     /** The number of transactions in the last assembled block (excluding coinbase transaction) */
     inline static std::optional<int64_t> m_last_block_num_txs{};

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -205,6 +205,15 @@ public:
     /** Add transactions matching previously requested wtxids. Throws on null
      *  or unexpected transactions, in which case nothing is added. */
     void AddMissingTxs(const std::vector<CTransactionRef>& txs) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /**
+     * Assemble and validate a block template from the collected transactions.
+     * If @p coinbase is provided the block is validated with it, otherwise a
+     * node-generated dummy coinbase is used.
+     */
+    std::unique_ptr<CBlockTemplate> MakeTemplate(const uint256& prevhash,
+                                                 const CTransactionRef& coinbase,
+                                                 std::string& reason,
+                                                 std::string& debug) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
 private:
     /** Requested transaction order as provided by the client. */

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -13,12 +13,14 @@
 #include <threadsafety.h>
 #include <txmempool.h>
 #include <util/feefrac.h>
+#include <util/hasher.h>
 #include <util/time.h>
 
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class CBlockIndex;
@@ -38,6 +40,7 @@ using interfaces::BlockRef;
 
 namespace node {
 class KernelNotifications;
+struct NodeContext;
 
 struct CBlockTemplate
 {
@@ -177,6 +180,22 @@ std::optional<BlockRef> WaitTipChanged(ChainstateManager& chainman, KernelNotifi
  * @returns false if interrupted.
  */
 bool CooldownIfHeadersAhead(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const BlockRef& last_tip, bool& interrupt_mining);
+
+/** Node-side implementation of the interfaces::TxCollection interface: holds
+ *  the client-requested transactions, tracks which are still missing, and
+ *  assembles them into a block template. */
+class TxCollection
+{
+public:
+    TxCollection(std::vector<Wtxid> wtxids, const NodeContext& node);
+
+private:
+    /** Requested transaction order as provided by the client. */
+    const std::vector<Wtxid> m_wtxids;
+    /** Collected transactions keyed by wtxid. */
+    std::unordered_map<Wtxid, CTransactionRef, SaltedWtxidHasher> m_transactions;
+    const NodeContext& m_node;
+};
 } // namespace node
 
 #endif // BITCOIN_NODE_MINER_H

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -188,6 +188,8 @@ class TxCollection
 {
 public:
     TxCollection(std::vector<Wtxid> wtxids, const NodeContext& node);
+    /** Return zero-based positions for requested transactions that are still missing. */
+    std::vector<uint32_t> UnknownTxPos() const;
 
 private:
     /** Requested transaction order as provided by the client. */

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -10,7 +10,7 @@
 #include <node/mining_types.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
-#include <threadsafety.h>
+#include <sync.h>
 #include <txmempool.h>
 #include <util/feefrac.h>
 #include <util/hasher.h>
@@ -189,13 +189,19 @@ class TxCollection
 public:
     TxCollection(std::vector<Wtxid> wtxids, const NodeContext& node);
     /** Return zero-based positions for requested transactions that are still missing. */
-    std::vector<uint32_t> UnknownTxPos() const;
+    std::vector<uint32_t> UnknownTxPos() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Add transactions matching previously requested wtxids. Throws on null
+     *  or unexpected transactions, in which case nothing is added. */
+    void AddMissingTxs(const std::vector<CTransactionRef>& txs) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
 private:
     /** Requested transaction order as provided by the client. */
     const std::vector<Wtxid> m_wtxids;
+    /** Protects m_transactions: IPC clients may call methods concurrently
+     *  from different threads. */
+    mutable Mutex m_mutex;
     /** Collected transactions keyed by wtxid. */
-    std::unordered_map<Wtxid, CTransactionRef, SaltedWtxidHasher> m_transactions;
+    std::unordered_map<Wtxid, CTransactionRef, SaltedWtxidHasher> m_transactions GUARDED_BY(m_mutex);
     const NodeContext& m_node;
 };
 } // namespace node

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -16,10 +16,13 @@
 #include <util/hasher.h>
 #include <util/time.h>
 
+#include <condition_variable>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -195,16 +198,26 @@ bool CooldownIfHeadersAhead(ChainstateManager& chainman, KernelNotifications& ke
 
 /** Node-side implementation of the interfaces::TxCollection interface: holds
  *  the client-requested transactions, tracks which are still missing, and
- *  assembles them into a block template. */
+ *  assembles them into a block template.
+ *
+ *  A background thread prefetches the input coins of collected transactions
+ *  into the active chainstate's coins cache, so that by the time the client
+ *  calls MakeTemplate() its TestBlockValidity() check does not have to read
+ *  them from disk. Prefetch work is queued by the constructor and by
+ *  AddMissingTxs(), both of which return without waiting for it. */
 class TxCollection
 {
 public:
     TxCollection(std::vector<Wtxid> wtxids, const NodeContext& node);
+    ~TxCollection();
     /** Return zero-based positions for requested transactions that are still missing. */
     std::vector<uint32_t> UnknownTxPos() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
     /** Add transactions matching previously requested wtxids. Throws on null
      *  or unexpected transactions, in which case nothing is added. */
     void AddMissingTxs(const std::vector<CTransactionRef>& txs) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Block until all queued input coins have been prefetched. Only useful
+     *  for tests and benchmarks; MakeTemplate() does not require it. */
+    void WaitForPrefetch() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
     /**
      * Assemble and validate a block template from the collected transactions.
      * If @p coinbase is provided the block is validated with it, otherwise a
@@ -216,6 +229,13 @@ public:
                                                  std::string& debug) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
 private:
+    /** Queue the input coins of @p txs for prefetching, skipping inputs that
+     *  spend outputs of other transactions in the collection. */
+    void QueuePrefetch(const std::vector<CTransactionRef>& txs) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
+    /** Background thread: fetch queued coins into the active chainstate's
+     *  coins cache in small batches, taking cs_main per batch. */
+    void PrefetchThread() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
     /** Requested transaction order as provided by the client. */
     const std::vector<Wtxid> m_wtxids;
     /** Protects m_transactions: IPC clients may call methods concurrently
@@ -223,6 +243,15 @@ private:
     mutable Mutex m_mutex;
     /** Collected transactions keyed by wtxid. */
     std::unordered_map<Wtxid, CTransactionRef, SaltedWtxidHasher> m_transactions GUARDED_BY(m_mutex);
+    /** Input coins waiting to be prefetched. */
+    std::deque<COutPoint> m_prefetch_queue GUARDED_BY(m_mutex);
+    /** Set to true when the prefetch thread is fetching a batch. */
+    bool m_prefetch_busy GUARDED_BY(m_mutex){false};
+    /** Tells the prefetch thread to exit. */
+    bool m_prefetch_stop GUARDED_BY(m_mutex){false};
+    /** Signals new work, completed work and shutdown to/from the prefetch thread. */
+    mutable std::condition_variable m_prefetch_cv;
+    std::thread m_prefetch_thread;
     const NodeContext& m_node;
 };
 } // namespace node

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -47,6 +47,7 @@ from test_framework.ipc_util import (
     mining_get_block,
     mining_get_coinbase_tx,
     mining_wait_next_template,
+    tx_collection_make_template,
     tx_collection_unknown_pos,
     wait_and_do,
 )
@@ -345,9 +346,16 @@ class IPCMiningTest(BitcoinTestFramework):
                 assert_equal(e.description, f"remote exception: std::exception: duplicate wtxid {ser_uint256(1)[::-1].hex()}")
                 assert_equal(e.type, "FAILED")
 
-            self.log.debug("Create and destroy an empty collection")
-            async with destroying((await mining0.collectTxs(ctx0, [])).result, ctx0):
-                pass
+            self.log.debug("An empty collection can immediately build a coinbase-only template")
+            async with AsyncExitStack() as stack:
+                tx_collection = await stack.enter_async_context(destroying((await mining0.collectTxs(ctx0, [])).result, ctx0))
+                tip = bytes((await mining0.getTip(ctx0)).result.hash)
+                response = await tx_collection.makeTemplate(ctx0, tip)
+                assert_equal(response.reason, "")
+                assert_equal(response.debug, "")
+                template = await stack.enter_async_context(destroying(response.result, ctx0))
+                block = await mining_get_block(template, ctx0)
+                assert_equal(len(block.vtx), 1)
 
             self.log.debug("Run the TxCollection workflow")
             self.sync_blocks()
@@ -359,6 +367,8 @@ class IPCMiningTest(BitcoinTestFramework):
                 confirmed_only=True,
             )
             self.sync_mempools()
+            current_tip_info = await mining0.getTip(ctx0)
+            current_tip = bytes(current_tip_info.result.hash)
 
             # Keep the mempools separate for the rest of the test. Remote
             # blocks will be relayed explicitly later instead of reconnecting.
@@ -387,6 +397,11 @@ class IPCMiningTest(BitcoinTestFramework):
                 # remote node.
                 assert_equal(await tx_collection_unknown_pos(tx_collection, ctx0), [1])
 
+                self.log.debug("makeTemplate() should fail while transactions are still missing")
+                await tx_collection_make_template(
+                    tx_collection, stack, ctx0, current_tip, reject_reason="missing-txs"
+                )
+
                 self.log.debug("Reject unexpected transactions in addMissingTxs(), leaving the collection unchanged")
                 unexpected_tx = remote_wallet.create_self_transfer(fee_rate=10, confirmed_only=True)
                 try:
@@ -413,8 +428,91 @@ class IPCMiningTest(BitcoinTestFramework):
                 await tx_collection.addMissingTxs(ctx0, [raw_txs[1]])
                 assert_equal(await tx_collection_unknown_pos(tx_collection, ctx0), [])
 
+                # Mine an empty block so the reference transactions stay in
+                # both mempools while the tip-handling checks run.
+                future_block = self.generateblock(
+                    remote_node,
+                    output="raw(52)",
+                    transactions=[],
+                    submit=False,
+                    sync_fun=self.no_op,
+                )["hex"]
+                assert_equal(remote_node.submitblock(future_block), None)
+                future_tip_info = await mining1.getTip(ctx1)
+                future_tip = bytes(future_tip_info.result.hash)
+
+                self.log.debug("makeTemplate() should reject a prevhash that does not match the current tip")
+                await tx_collection_make_template(
+                    tx_collection, stack, ctx0, future_tip, reject_reason="inconclusive-not-best-prevblk"
+                )
+
+                self.log.debug("Relay the remote block and wait for the local tip to catch up")
+                assert_equal(node.submitblock(future_block), None)
+                self.wait_until(lambda: node.getbestblockhash() == remote_node.getbestblockhash())
+
+                self.log.debug("makeTemplate() should report a prevhash the tip has moved past as stale")
+                await tx_collection_make_template(
+                    tx_collection, stack, ctx0, current_tip, reject_reason="stale-prevblk"
+                )
+
+                self.log.debug("Remote node rebuilds the reference template on the new tip")
+                remote_template = await mining_create_block_template(mining1, stack, ctx1, self.default_block_create_options)
+                assert remote_template is not None
+                remote_tip_info = await mining1.getTip(ctx1)
+                remote_tip = bytes(remote_tip_info.result.hash)
+                remote_block = await mining_get_block(remote_template, ctx1)
+                assert_equal([tx.wtxid_hex for tx in remote_block.vtx[1:]], [shared_tx["wtxid"], missing_tx["wtxid"]])
+
+                template = await tx_collection_make_template(tx_collection, stack, ctx0, remote_tip)
+                local_block = await mining_get_block(template, ctx0)
+
+                assert_equal([tx.wtxid_hex for tx in local_block.vtx[1:]], [tx.wtxid_hex for tx in remote_block.vtx[1:]])
+
+                self.log.debug("makeTemplate() validates a client-provided coinbase")
+                remote_coinbase = remote_block.vtx[0]
+                template_cb = await tx_collection_make_template(
+                    tx_collection, stack, ctx0, remote_tip, coinbase=remote_coinbase.serialize()
+                )
+                block_cb = await mining_get_block(template_cb, ctx0)
+                assert_equal(block_cb.vtx[0].serialize(), remote_coinbase.serialize())
+
+                self.log.debug("makeTemplate() rejects an overpaying client-provided coinbase")
+                overpaying_coinbase = deepcopy(remote_coinbase)
+                overpaying_coinbase.vout[0].nValue += 1
+                await tx_collection_make_template(
+                    tx_collection, stack, ctx0, remote_tip,
+                    coinbase=overpaying_coinbase.serialize(),
+                    reject_reason="bad-cb-amount",
+                )
+
+                self.log.debug("Solve the reconstructed block and submit the same solution to both templates")
+                # makeTemplate() leaves the merkle root unset (it validates with
+                # check_merkle_root=false); submitSolution() fills it in. Set it
+                # here too so the solved proof-of-work matches the submitted block.
+                local_block.hashMerkleRoot = local_block.calc_merkle_root()
+                local_block.solve()
+                version = local_block.nVersion
+                time = local_block.nTime
+                nonce = local_block.nNonce
+                coinbase = local_block.vtx[0].serialize()
+
+                submitted_local = (await template.submitSolution(ctx0, version, time, nonce, coinbase)).result
+                assert_equal(submitted_local, True)
+
+                submitted_remote = (await remote_template.submitSolution(ctx1, version, time, nonce, coinbase)).result
+                assert_equal(submitted_remote, True)
+                assert_equal(node.getbestblockhash(), remote_node.getbestblockhash())
+
+                self.log.debug("makeTemplate() should reject collected transactions already in the chain")
+                # The collection still references the transactions just mined
+                # above, so reassembling them on the new tip is a BIP30
+                # duplicate and fails validation.
+                new_tip = bytes((await mining0.getTip(ctx0)).result.hash)
+                await tx_collection_make_template(
+                    tx_collection, stack, ctx0, new_tip, reject_reason="bad-txns-BIP30"
+                )
+
             self.connect_nodes(0, 1)
-            self.generate(remote_node, 1, sync_fun=self.no_op)
             self.sync_blocks()
 
         asyncio.run(capnp.run(async_routine()))

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -379,12 +379,39 @@ class IPCMiningTest(BitcoinTestFramework):
                 assert_equal([tx.wtxid_hex for tx in remote_block.vtx[1:]], [shared_tx["wtxid"], missing_tx["wtxid"]])
 
                 requested_wtxids = [tx.wtxid for tx in remote_block.vtx[1:]]
+                raw_txs = [tx.serialize() for tx in remote_block.vtx[1:]]
                 tx_collection = await mining_collect_txs(mining0, stack, ctx0, requested_wtxids)
 
                 # The first transaction is already in node's mempool, but
                 # the child transaction only exists on the disconnected
                 # remote node.
                 assert_equal(await tx_collection_unknown_pos(tx_collection, ctx0), [1])
+
+                self.log.debug("Reject unexpected transactions in addMissingTxs(), leaving the collection unchanged")
+                unexpected_tx = remote_wallet.create_self_transfer(fee_rate=10, confirmed_only=True)
+                try:
+                    await tx_collection.addMissingTxs(ctx0, [raw_txs[1], unexpected_tx["tx"].serialize()])
+                    raise AssertionError("addMissingTxs unexpectedly accepted an unknown wtxid")
+                except capnp.lib.capnp.KjException as e:
+                    assert_equal(e.description, f"remote exception: std::exception: unexpected wtxid {unexpected_tx['wtxid']}")
+                    assert_equal(e.type, "FAILED")
+                # The unexpected transaction causes the whole call to fail, so
+                # the missing transaction it was submitted with is not added.
+                assert_equal(await tx_collection_unknown_pos(tx_collection, ctx0), [1])
+
+                self.log.debug("Reject null transactions in addMissingTxs(), leaving the collection unchanged")
+                # An empty Data field deserializes to a null CTransactionRef.
+                try:
+                    await tx_collection.addMissingTxs(ctx0, [raw_txs[1], b""])
+                    raise AssertionError("addMissingTxs unexpectedly accepted a null transaction")
+                except capnp.lib.capnp.KjException as e:
+                    assert_equal(e.description, "remote exception: std::exception: unexpected null transaction")
+                    assert_equal(e.type, "FAILED")
+                assert_equal(await tx_collection_unknown_pos(tx_collection, ctx0), [1])
+
+                self.log.debug("Add the missing transaction")
+                await tx_collection.addMissingTxs(ctx0, [raw_txs[1]])
+                assert_equal(await tx_collection_unknown_pos(tx_collection, ctx0), [])
 
             self.connect_nodes(0, 1)
             self.generate(remote_node, 1, sync_fun=self.no_op)

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -321,6 +321,27 @@ class IPCMiningTest(BitcoinTestFramework):
 
         asyncio.run(capnp.run(async_routine()))
 
+    def run_tx_collection_test(self):
+        """Test TxCollection behavior."""
+        self.log.info("Running TxCollection test")
+
+        async def async_routine():
+            ctx0, mining0 = await make_mining_ctx(self)
+
+            self.log.debug("collectTxs() should reject duplicate wtxids")
+            try:
+                await mining0.collectTxs(ctx0, [ser_uint256(1), ser_uint256(1)])
+                raise AssertionError("collectTxs unexpectedly accepted duplicate wtxids")
+            except capnp.lib.capnp.KjException as e:
+                assert_equal(e.description, f"remote exception: std::exception: duplicate wtxid {ser_uint256(1)[::-1].hex()}")
+                assert_equal(e.type, "FAILED")
+
+            self.log.debug("Create and destroy an empty collection")
+            async with destroying((await mining0.collectTxs(ctx0, [])).result, ctx0):
+                pass
+
+        asyncio.run(capnp.run(async_routine()))
+
     def run_ipc_option_override_test(self):
         self.log.info("Running IPC option override test")
         # Confirm that BlockCreateOptions.blockReservedWeight takes precedence
@@ -816,6 +837,7 @@ class IPCMiningTest(BitcoinTestFramework):
         self.run_mining_interface_test()
         self.run_early_startup_test()
         self.run_block_template_test()
+        self.run_tx_collection_test()
         self.run_coinbase_and_submission_test()
         self.run_waitnext_mining_policy_test()
         self.run_block_max_weight_test()

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -42,10 +42,12 @@ from test_framework.ipc_util import (
     destroying,
     load_capnp_modules,
     make_mining_ctx,
+    mining_collect_txs,
     mining_create_block_template,
     mining_get_block,
     mining_get_coinbase_tx,
     mining_wait_next_template,
+    tx_collection_unknown_pos,
     wait_and_do,
 )
 
@@ -66,7 +68,7 @@ class IPCMiningTest(BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_nodes(self):
-        self.extra_init = [{"ipcbind": True}, {}, {"ipcbind": True}]
+        self.extra_init = [{"ipcbind": True}, {"ipcbind": True}, {"ipcbind": True}]
         super().setup_nodes()
         # Use this function to also load the capnp modules (we cannot use set_test_params for this,
         # as it is being called before knowing whether capnp is available).
@@ -320,13 +322,20 @@ class IPCMiningTest(BitcoinTestFramework):
                 await wait_and_do(wait_for_block(), template6.interruptWait())
 
         asyncio.run(capnp.run(async_routine()))
+        # This test adds transactions to the mempool without mining them.
+        # Confirm them so later tests start from a clean mempool.
+        self.generate(self.nodes[0], 1)
 
     def run_tx_collection_test(self):
         """Test TxCollection behavior."""
         self.log.info("Running TxCollection test")
 
         async def async_routine():
+            node = self.nodes[0]
+            remote_node = self.nodes[1]
             ctx0, mining0 = await make_mining_ctx(self)
+            ctx1, mining1 = await make_mining_ctx(self, node_index=1)
+            remote_wallet = MiniWallet(remote_node)
 
             self.log.debug("collectTxs() should reject duplicate wtxids")
             try:
@@ -340,7 +349,51 @@ class IPCMiningTest(BitcoinTestFramework):
             async with destroying((await mining0.collectTxs(ctx0, [])).result, ctx0):
                 pass
 
+            self.log.debug("Run the TxCollection workflow")
+            self.sync_blocks()
+            remote_wallet.rescan_utxos()
+            self.log.debug("Create a transaction that is shared by both mempools before disconnecting")
+            shared_tx = remote_wallet.send_self_transfer(
+                from_node=remote_node,
+                fee_rate=10,
+                confirmed_only=True,
+            )
+            self.sync_mempools()
+
+            # Keep the mempools separate for the rest of the test. Remote
+            # blocks will be relayed explicitly later instead of reconnecting.
+            self.disconnect_nodes(0, 1)
+
+            async with AsyncExitStack() as stack:
+                self.log.debug("Create a second transaction that stays only in the remote mempool")
+                missing_tx = remote_wallet.send_self_transfer(
+                    from_node=remote_node,
+                    utxo_to_spend=shared_tx["new_utxo"],
+                    fee_rate=10,
+                )
+
+                self.log.debug("Remote node builds the reference template that node will reconstruct")
+                remote_template = await mining_create_block_template(mining1, stack, ctx1, self.default_block_create_options)
+                assert remote_template is not None
+                remote_block = await mining_get_block(remote_template, ctx1)
+                assert_equal([tx.wtxid_hex for tx in remote_block.vtx[1:]], [shared_tx["wtxid"], missing_tx["wtxid"]])
+
+                requested_wtxids = [tx.wtxid for tx in remote_block.vtx[1:]]
+                tx_collection = await mining_collect_txs(mining0, stack, ctx0, requested_wtxids)
+
+                # The first transaction is already in node's mempool, but
+                # the child transaction only exists on the disconnected
+                # remote node.
+                assert_equal(await tx_collection_unknown_pos(tx_collection, ctx0), [1])
+
+            self.connect_nodes(0, 1)
+            self.generate(remote_node, 1, sync_fun=self.no_op)
+            self.sync_blocks()
+
         asyncio.run(capnp.run(async_routine()))
+        # Test cleanup
+        self.sync_blocks()
+        self.miniwallet.rescan_utxos()
 
     def run_ipc_option_override_test(self):
         self.log.info("Running IPC option override test")

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -357,6 +357,20 @@ class IPCMiningTest(BitcoinTestFramework):
                 block = await mining_get_block(template, ctx0)
                 assert_equal(len(block.vtx), 1)
 
+                self.log.debug("Externally generated templates should reject coinbase, fee, sigop, and waitNext accessors")
+                for method_name, method in (
+                    ("getCoinbaseTx", template.getCoinbaseTx),
+                    ("getTxFees", template.getTxFees),
+                    ("getTxSigops", template.getTxSigops),
+                    ("waitNext", template.waitNext),
+                ):
+                    try:
+                        await method(ctx0)
+                        raise AssertionError(f"{method_name} unexpectedly succeeded on external template")
+                    except capnp.lib.capnp.KjException as e:
+                        assert_equal(e.description, f"remote exception: std::exception: {method_name} is unavailable for externally generated templates")
+                        assert_equal(e.type, "FAILED")
+
             self.log.debug("Run the TxCollection workflow")
             self.sync_blocks()
             remote_wallet.rescan_utxos()

--- a/test/functional/test_framework/ipc_util.py
+++ b/test/functional/test_framework/ipc_util.py
@@ -134,6 +134,23 @@ async def tx_collection_unknown_pos(tx_collection, ctx):
     return list((await tx_collection.unknownTxPos(ctx)).result)
 
 
+async def tx_collection_make_template(tx_collection, stack, ctx, prevhash, *, coinbase=None, reject_reason=None, debug=None):
+    if coinbase is None:
+        response = await tx_collection.makeTemplate(ctx, prevhash)
+    else:
+        response = await tx_collection.makeTemplate(ctx, prevhash, coinbase)
+    if reject_reason is not None:
+        assert_equal(response._has("result"), False)
+        assert_equal(response.reason, reject_reason)
+        if debug is not None:
+            assert_equal(response.debug, debug)
+        return None
+    assert_equal(response._has("result"), True)
+    assert_equal(response.reason, "")
+    assert_equal(response.debug, "")
+    return await stack.enter_async_context(destroying(response.result, ctx))
+
+
 async def mining_get_block(block_template, ctx):
     block_data = BytesIO((await block_template.getBlock(ctx)).result)
     block = CBlock()

--- a/test/functional/test_framework/ipc_util.py
+++ b/test/functional/test_framework/ipc_util.py
@@ -117,12 +117,21 @@ async def mining_create_block_template(mining, stack, ctx, *args, **kwargs):
     return await stack.enter_async_context(destroying(response.result, ctx))
 
 
+async def mining_collect_txs(mining, stack, ctx, wtxids):
+    """Call mining.collectTxs() and return collection, then destroy when stack exits."""
+    return await stack.enter_async_context(destroying((await mining.collectTxs(ctx, wtxids)).result, ctx))
+
+
 async def mining_wait_next_template(template, stack, ctx, opts):
     """Call template.waitNext() and return template, then call template.destroy() when stack exits."""
     response = await template.waitNext(ctx, opts)
     if not response._has("result"):
         return None
     return await stack.enter_async_context(destroying(response.result, ctx))
+
+
+async def tx_collection_unknown_pos(tx_collection, ctx):
+    return list((await tx_collection.unknownTxPos(ctx)).result)
 
 
 async def mining_get_block(block_template, ctx):


### PR DESCRIPTION
Have the `TxCollection` constructor spin up a background thread to fetch coins from the UTXO set. Meanwhile the Job Declarator Server (IPC client) can query `unknownTxPos()` and fetch missing transactions from the miner.

This saves a little bit of time when `makeTemplate()` validates the template. 

benchmark | time
-- | --
`TxCollectionTemplateColdCoins` | 2.66 ms/template
`TxCollectionTemplatePrefetchedCoins` | 1.51 ms/template
`TxCollectionPrefetch` (the part hidden in the client round-trip) | 0.75 ms

A benchmark on mainnet would be more useful, in order to compare this to typical network roundtrip times when fetching missing transactions.

Builds on:
- https://github.com/bitcoin/bitcoin/pull/35671

(fully vibe coded proof-of-concept)